### PR TITLE
Deal with domain's NetBIOS name, add the security descriptor option

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -19,674 +19,674 @@ import sys
 
 class Ldeep(Command):
 
-    def __init__(self, ldap_connection, format="json"):
-        try:
-            self.ldap = ldap_connection
-        except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-            error(e)
-
-        if format == "json":
-            self.__display = self.__display_json
-
-    def display(self, records, verbose=False, specify_group=True):
-        def default(o):
-            if isinstance(o, date) or isinstance(o, datetime):
-                return o.isoformat()
-            elif isinstance(o, bytes):
-                return base64.b64encode(o).decode('ascii')
-
-        if verbose:
-            self.__display(list(map(dict, records)), default)
-        else:
-            for record in records:
-                if "group" in record["objectClass"]:
-                    print(record["sAMAccountName"] + (" (group)" if specify_group else ""))
-                elif "user" in record["objectClass"]:
-                    print(record["sAMAccountName"])
-                elif "dnsNode" in record["objectClass"]:
-                    print("{dc} {rec}".format(dc=record["dc"], rec=" ".join(record["dnsRecord"])))
-                elif "dnsZone" in record["objectClass"]:
-                    print(record["dc"])
-                elif "domain" in record["objectClass"]:
-                    print(record["dn"])
-
-    def __display_json(self, records, default):
-        json_dump(records, sys.stdout, ensure_ascii=False, default=default, sort_keys=True, indent=2)
-
-    # LISTERS #
-
-    def list_users(self, kwargs):
-        """
-        List users according to a filter.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            @filter:string = ["all", "spn", "enabled", "disabled", "locked", "nopasswordexpire", "passwordexpired", "nokrbpreauth", "reversible"]
-        """
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-        filter_ = kwargs.get("filter", "all")
-
-        if verbose:
-            attributes = ALL
-        else:
-            attributes = ["samAccountName", "objectClass"]
-
-        if security:
-            attributes = attributes + ['ntSecurityDescriptor']
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        if filter_ == "all":
-            results = self.ldap.query(USER_ALL_FILTER, attributes, controls=controls)
-        elif filter_ == "spn":
-            results = self.ldap.query(USER_SPN_FILTER, attributes, controls=controls)
-        elif filter_ == "enabled":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER_NEG.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
-        elif filter_ == "disabled":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
-        elif filter_ == "locked":
-            results = self.ldap.query(USER_LOCKED_FILTER, attributes, controls=controls)
-        elif filter_ == "nopasswordexpire":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_EXPIRE_PASSWORD"]), attributes, controls=controls)
-        elif filter_ == "passwordexpired":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["PASSWORD_EXPIRED"]), attributes, controls=controls)
-        elif filter_ == "nokrbpreauth":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_REQ_PREAUTH"]), attributes, controls=controls)
-        elif filter_ == "reversible":
-            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ENCRYPTED_TEXT_PWD_ALLOWED"]), attributes, controls=controls)
-        else:
-            return None
-
-        self.display(results, verbose)
-
-    def list_groups(self, kwargs):
-        """
-        List the groups.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-        """
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if not verbose:
-            attributes = ["samAccountName", "objectClass"]
-        else:
-            attributes = ALL
-
-        if security:
-            attributes = attributes + ['ntSecurityDescriptor']
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        self.display(self.ldap.query(GROUPS_FILTER, attributes, controls=controls), verbose, specify_group=False)
-
-    def list_machines(self, kwargs):
-        """
-        List the machine accounts.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-        """
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if not verbose:
-            attributes = ["samAccountName", "objectClass"]
-        else:
-            attributes = ALL
-
-        if security:
-            attributes = attributes + ['ntSecurityDescriptor']
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        self.display(self.ldap.query(COMPUTERS_FILTER, attributes, controls=controls), verbose, specify_group=False)
-
-    def list_computers(self, kwargs):
-        """
-        List the computer hostnames and resolve them if --resolve is specify.
-
-        Arguments:
-            @resolve:bool
-                A resolution on all computer names will be performed
-            @dns:string
-                An optional DNS server to use for the resolution
-        """
-        resolve = "resolve" in kwargs and kwargs["resolve"]
-        dns = kwargs.get("dns", "")
-
-        hostnames = []
-        results = self.ldap.query(COMPUTERS_FILTER, ["name"])
-        for result in results:
-            computer_name = result["name"]
-            hostnames.append("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
-            # print only if resolution was not mandated
-            if not resolve:
-                print("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
-        # do the resolution
-        if resolve:
-            for computer in utils_resolve(hostnames, dns):
-                print("{addr:20} {name}".format(addr=computer["address"], name=computer["hostname"]))
-
-    def list_domain_policy(self, kwargs):
-        """
-        Return the domain policy.
-        """
-        FILETIME_TIMESTAMP_FIELDS = {
-            "lockOutObservationWindow": (60, "mins"),
-            "lockoutDuration": (60, "mins"),
-            "maxPwdAge": (86400, "days"),
-            "minPwdAge": (86400, "days"),
-            "forceLogoff": (60, "mins")
-        }
-        FIELDS_TO_PRINT = ["dc", "distinguishedName", "lockOutObservationWindow", "lockoutDuration", "lockoutThreshold", "maxPwdAge", "minPwdAge", "minPwdLength", "pwdHistoryLength", "pwdProperties"]
-        policy = self.ldap.query(DOMAIN_INFO_FILTER)
-        if policy:
-            policy = policy[0]
-            for field in FIELDS_TO_PRINT:
-                val = policy[field]
-
-                if field == "lockOutObservationWindow" and isinstance(val, timedelta):
-                    val = int(val.total_seconds()) / 60
-                elif field in FILETIME_TIMESTAMP_FIELDS.keys() and type(val) == int:
-                    val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
-                if field in FILETIME_TIMESTAMP_FIELDS.keys():
-                    val = "%d %s" % (val, FILETIME_TIMESTAMP_FIELDS[field][1])
-
-                print("%s: %s" % (field, val))
-
-    def list_ou(self, kwargs):
-        """
-        Return the list of organizational units with linked GPO.
-        """
-        cn_re = re_compile("{[^}]+}")
-        results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
-        gpos = {}
-        for gpo in results:
-            gpos[gpo["cn"]] = gpo["displayName"]
-
-        results = self.ldap.query(OU_FILTER)
-        for result in results:
-            print(result["distinguishedName"])
-            if "gPLink" in result:
-                guids = cn_re.findall(result["gPLink"])
-                if len(guids) > 0:
-                    print("[gPLink]")
-                    print("* {}".format("\n* ".join([gpos[g] if g in gpos else g for g in guids])))
-
-    def list_gpo(self, kwargs):
-        """
-        Return the list of Group policy objects.
-        """
-        results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
-        for gpo in results:
-            print("{cn}: {name}".format(cn=gpo["cn"], name=gpo["displayName"]))
-
-    def list_pso(self, kwargs):
-        """
-        List the Password Settings Objects.
-        """
-        FILETIME_TIMESTAMP_FIELDS = {
-            "msDS-LockoutObservationWindow": (60, "mins"),
-            "msDS-MinimumPasswordAge": (86400, "days"),
-            "msDS-MaximumPasswordAge": (86400, "days"),
-            "msDS-LockoutDuration": (60, "mins")
-        }
-        FIELDS_TO_PRINT = [
-            "cn",
-            "msDS-PasswordReversibleEncryptionEnabled",
-            "msDS-PasswordSettingsPrecedence",
-            "msDS-MinimumPasswordLength",
-            "msDS-PasswordHistoryLength",
-            "msDS-PasswordComplexityEnabled",
-            "msDS-LockoutObservationWindow",
-            "msDS-LockoutDuration",
-            "msDS-LockoutThreshold",
-            "msDS-MinimumPasswordAge",
-            "msDS-MaximumPasswordAge",
-        ]
-        psos = self.ldap.query(PSO_INFO_FILTER)
-        for policy in psos:
-            for field in FIELDS_TO_PRINT:
-                if isinstance(policy[field], list):
-                    val = policy[field][0]
-                else:
-                    val = policy[field]
-
-                if field in FILETIME_TIMESTAMP_FIELDS.keys():
-                    val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
-                    val = "{val} {typ}".format(val=val, typ=FILETIME_TIMESTAMP_FIELDS[field][1])
-                print("{field}: {val}".format(field=field, val=val))
-
-    def list_trusts(self, kwargs):
-        """
-        List the domain's trust relationships.
-        """
-        results = self.ldap.query(TRUSTS_INFO_FILTER)
-        FIELDS_TO_PRINT = ["dn", "cn", "securityIdentifier", "name", "trustDirection", "trustPartner", "trustType", "trustAttributes", "flatName"]
-        for result in results:
-            for field in FIELDS_TO_PRINT:
-                if field in result:
-                    val = result[field]
-                    if field == "trustDirection":
-                        if int(val) == 0x00000003:
-                            val = "bidirectional"
-                        elif int(val) == 0x00000002:
-                            val = "outbound"
-                        elif int(val) == 0x00000001:
-                            val = "inbound"
-                        elif int(val) == 0x00000000:
-                            val = "disabled"
-                    elif field == "trustType":
-                        if int(val) == 0x00000001:
-                            val = "Non running Windows domain"
-                        elif int(val) == 0x00000002:
-                            val = "Windows domain running Active Directory"
-                        elif int(val) == 0x00000003:
-                            val = "Non Windows domain"
-                    print("{field}: {val}".format(field=field, val=val))
-            print("")
-
-    def list_zones(self, kwargs):
-        """
-        List the DNS zones configured in the Active Directory.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-        """
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if not verbose:
-            attributes = ["dc", "objectClass"]
-        else:
-            attributes = ALL
-
-        if security:
-            attributes = attributes + ['ntSecurityDescriptor']
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        self.display(
-            self.ldap.query(
-                ZONES_FILTER,
-                attributes,
-                controls=controls,
-                base=','.join(["CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
-            ),
-            verbose
-        )
-
-    # GETTERS #
-
-    def get_zone(self, kwargs):
-        """
-        Return the records of a DNS zone.
-
-        Arguments:
-            #dns_zone:string
-                DNS zone to retrieve records
-        """
-        dns_zone = kwargs["dns_zone"]
-        try:
-            results = self.ldap.query(
-                ZONE_FILTER,
-                base=','.join(["DC={}".format(dns_zone), "CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
-            )
-        except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-            error(e)
-        else:
-            self.display(results)
-
-    def get_membersof(self, kwargs):
-        """
-        List the members of `group`.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #group:string
-                Group to list members
-        """
-        group = kwargs["group"]
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        attributes = ["distinguishedName", "objectSid"]
-
-        if security:
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        results = self.ldap.query(GROUP_DN_FILTER.format(group=group), attributes)
-        if results:
-            group_dn = results[0]["distinguishedName"]
-        else:
-            error("Group {group} does not exists".format(group=group))
-
-        primary_group_id = results[0]["objectSid"].split('-')[-1]
-        results = self.ldap.query(USERS_IN_GROUP_FILTER.format(group=group_dn, primary_group_id=primary_group_id), controls=controls)
-        self.display(results, verbose)
-
-    def get_memberships(self, kwargs):
-        """
-        List the group for which `users` belongs to.
-
-        Arguments:
-            #user:string
-                User to list memberships
-            @recursive:bool
-                List recursively the groups
-        """
-        user = kwargs["user"]
-        recursive = kwargs.get("recursive", False)
-
-        already_printed = set()
-
-        def lookup_groups(dn, leading_sp, already_treated):
-            groups = []
-            results = self.ldap.query("(distinguishedName={})".format(dn), ["memberOf"])
-            for result in results:
-                if "memberOf" in result:
-                    for group_dn in result["memberOf"]:
-                        if group_dn not in already_treated:
-                            print("{g:>{width}}".format(g=group_dn, width=leading_sp + len(group_dn)))
-                            already_treated.add(group_dn)
-                            lookup_groups(group_dn, leading_sp + 4, already_treated)
-
-            return already_treated
-
-        results = self.ldap.query(USER_IN_GROUPS_FILTER.format(username=user), ["memberOf"])
-        for result in results:
-            if "memberOf" in result:
-                for group_dn in result["memberOf"]:
-                    print(group_dn)
-                    if recursive:
-                        already_printed.add(group_dn)
-                        s = lookup_groups(group_dn, 4, already_printed)
-                        already_printed.union(s)
-            else:
-                error("No groups for user {}".format(user))
-
-    def get_from_sid(self, kwargs):
-        """
-        Return the object associated with the given `sid`.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #sid:string
-                SID to search for
-        """
-        sid = kwargs["sid"]
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if security:
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        try:
-            result = self.ldap.resolve_sid(sid, controls=controls)
-            if isinstance(result, str):
-                print(result)
-            else:
-                self.display(result, verbose)
-        except ActiveDirectoryView.ActiveDirectoryLdapInvalidSID:
-            error("Invalid SID")
-
-    def get_from_guid(self, kwargs):
-        """
-        Return the object associated with the given `guid`.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #guid:string
-                GUID to search for
-        """
-        guid = kwargs["guid"]
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if security:
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        try:
-            self.display(self.ldap.resolve_guid(guid, controls=controls), verbose)
-        except ActiveDirectoryView.ActiveDirectoryLdapInvalidGUID:
-            error("Invalid GUID")
-
-    def get_object(self, kwargs):
-        """
-        Return the records containing `object` in a CN.
-
-        Arguments:
-            @verbose:bool
-                Results will contain full information
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #object:string
-                Pattern to look for in CNs
-        """
-        anr = kwargs["object"]
-        verbose = kwargs.get("verbose", False)
-        security = kwargs.get("security", False)
-
-        if security:
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        results = self.ldap.query("(&(anr={ldap_object}))".format(ldap_object=anr), controls=controls)
-        self.display(results, verbose)
-
-    def get_sddl(self, kwargs):
-        """
-        Returns the SDDL of an object given it's CN.
-
-        Arguments:
-            #object:string
-                CN of object.
-        """
-        anr = kwargs["object"]
-
-        results = self.ldap.get_sddl("(anr={ldap_object})".format(ldap_object=anr))
-
-        self.display(results, True, False)
-
-    # MISC #
-
-    def misc_search(self, kwargs):
-        """
-        Query the LDAP with `filter` and retrieve ALL or `attributes` if specified.
-
-        Arguments:
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #filter:string
-                LDAP filter to search for
-            #attributes:string = 'ALL'
-                Comma separated list of attributes to display, ALL for every possible attribute
-        """
-        attr = kwargs["attributes"]
-        filter_ = kwargs["filter"]
-        security = kwargs.get("security", False)
-
-        if security:
-            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-        else:
-            controls = []
-
-        try:
-            if attr and attr != "ALL":
-                results = self.ldap.query(filter_, attr.split(","), controls=controls)
-            else:
-                results = self.ldap.query(filter_, controls=controls)
-            self.display(results, True)
-        except Exception as e:
-            error(e)
-
-    def misc_all(self, kwargs):
-        """
-        Collect and store computers, domain_policy, zones, gpo, groups, ou, users, trusts, pso information
-
-        Arguments:
-            @security:bool
-                Results will contain full information + security descriptors on objects
-            #output:string
-                File prefix for the files that will be created during the execution
-        """
-        output = kwargs["output"]
-        security = kwargs.get("security", False)
-        kwargs["verbose"] = False
-
-        for command, method in self.get_commands(prefix="list_"):
-            info("Retrieving {command} output".format(command=command))
-            if self.has_option(method, "filter"):
-                filter_ = self.retrieve_default_val_for_arg(method, "filter")
-                for f in filter_:
-                    sys.stdout = Logger("{output}_{command}_{filter}.lst".format(output=output, command=command, filter=f), quiet=True)
-                    kwargs["filter"] = f
-                    getattr(self, method)(kwargs)
-
-                    if self.has_option(method, "verbose"):
-                        if security:
-                            kwargs["security"] = True
-                        info("Retrieving {command} verbose output".format(command=command))
-                        sys.stdout = Logger("{output}_{command}_{filter}.json".format(output=output, command=command, filter=f), quiet=True)
-                        kwargs["verbose"] = True
-                        getattr(self, method)(kwargs)
-                        kwargs["verbose"] = False
-                        kwargs["security"] = False
-                kwargs["filter"] = None
-            else:
-                sys.stdout = Logger("{output}_{command}.lst".format(output=output, command=command), quiet=True)
-                getattr(self, method)(kwargs)
-
-                if self.has_option(method, "verbose"):
-                    if security:
-                        kwargs["security"] = True
-                    info("Retrieving {command} verbose output".format(command=command))
-                    sys.stdout = Logger("{output}_{command}.json".format(output=output, command=command), quiet=True)
-                    kwargs["verbose"] = True
-                    getattr(self, method)(kwargs)
-                    kwargs["verbose"] = False
-                    kwargs["security"] = False
-
-    # ACTION #
-
-    def action_unlock(self, kwargs):
-        """
-        Unlock `user`.
-
-        Arguments:
-            #user:string
-                User to unlock
-        """
-        user = kwargs["user"]
-
-        if self.ldap.unlock(user):
-            info("User {username} unlocked (or was already unlocked)".format(username=user))
-        else:
-            error("Unable to unlock {username}, check privileges".format(username=user))
-
-    def action_modify_password(self, kwargs):
-        """
-        Change `user`'s password.
-
-        Arguments:
-            #user:string
-                User to unlock
-            #newpassword:string
-                New password
-            #currpassword:string = None
-                Current password
-        """
-        user = kwargs["user"]
-        new = kwargs["newpassword"]
-        curr = kwargs.get("currpassword", None)
-        if curr == "None":
-            curr = None
-
-        if self.ldap.modify_password(user, curr, new):
-            info("Password of {username} changed".format(username=user))
-        else:
-            error("Unable to change {username}'s password, check privileges or try with ldaps://".format(username=user))
+	def __init__(self, ldap_connection, format="json"):
+		try:
+			self.ldap = ldap_connection
+		except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+			error(e)
+
+		if format == "json":
+			self.__display = self.__display_json
+
+	def display(self, records, verbose=False, specify_group=True):
+		def default(o):
+			if isinstance(o, date) or isinstance(o, datetime):
+				return o.isoformat()
+			elif isinstance(o, bytes):
+				return base64.b64encode(o).decode('ascii')
+
+		if verbose:
+			self.__display(list(map(dict, records)), default)
+		else:
+			for record in records:
+				if "group" in record["objectClass"]:
+					print(record["sAMAccountName"] + (" (group)" if specify_group else ""))
+				elif "user" in record["objectClass"]:
+					print(record["sAMAccountName"])
+				elif "dnsNode" in record["objectClass"]:
+					print("{dc} {rec}".format(dc=record["dc"], rec=" ".join(record["dnsRecord"])))
+				elif "dnsZone" in record["objectClass"]:
+					print(record["dc"])
+				elif "domain" in record["objectClass"]:
+					print(record["dn"])
+
+	def __display_json(self, records, default):
+		json_dump(records, sys.stdout, ensure_ascii=False, default=default, sort_keys=True, indent=2)
+
+	# LISTERS #
+
+	def list_users(self, kwargs):
+		"""
+		List users according to a filter.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			@filter:string = ["all", "spn", "enabled", "disabled", "locked", "nopasswordexpire", "passwordexpired", "nokrbpreauth", "reversible"]
+		"""
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+		filter_ = kwargs.get("filter", "all")
+
+		if verbose:
+			attributes = ALL
+		else:
+			attributes = ["samAccountName", "objectClass"]
+
+		if security:
+			attributes = attributes + ['ntSecurityDescriptor']
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		if filter_ == "all":
+			results = self.ldap.query(USER_ALL_FILTER, attributes, controls=controls)
+		elif filter_ == "spn":
+			results = self.ldap.query(USER_SPN_FILTER, attributes, controls=controls)
+		elif filter_ == "enabled":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER_NEG.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
+		elif filter_ == "disabled":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
+		elif filter_ == "locked":
+			results = self.ldap.query(USER_LOCKED_FILTER, attributes, controls=controls)
+		elif filter_ == "nopasswordexpire":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_EXPIRE_PASSWORD"]), attributes, controls=controls)
+		elif filter_ == "passwordexpired":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["PASSWORD_EXPIRED"]), attributes, controls=controls)
+		elif filter_ == "nokrbpreauth":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_REQ_PREAUTH"]), attributes, controls=controls)
+		elif filter_ == "reversible":
+			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ENCRYPTED_TEXT_PWD_ALLOWED"]), attributes, controls=controls)
+		else:
+			return None
+
+		self.display(results, verbose)
+
+	def list_groups(self, kwargs):
+		"""
+		List the groups.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+		"""
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if not verbose:
+			attributes = ["samAccountName", "objectClass"]
+		else:
+			attributes = ALL
+
+		if security:
+			attributes = attributes + ['ntSecurityDescriptor']
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		self.display(self.ldap.query(GROUPS_FILTER, attributes, controls=controls), verbose, specify_group=False)
+
+	def list_machines(self, kwargs):
+		"""
+		List the machine accounts.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+		"""
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if not verbose:
+			attributes = ["samAccountName", "objectClass"]
+		else:
+			attributes = ALL
+
+		if security:
+			attributes = attributes + ['ntSecurityDescriptor']
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		self.display(self.ldap.query(COMPUTERS_FILTER, attributes, controls=controls), verbose, specify_group=False)
+
+	def list_computers(self, kwargs):
+		"""
+		List the computer hostnames and resolve them if --resolve is specify.
+
+		Arguments:
+			@resolve:bool
+				A resolution on all computer names will be performed
+			@dns:string
+				An optional DNS server to use for the resolution
+		"""
+		resolve = "resolve" in kwargs and kwargs["resolve"]
+		dns = kwargs.get("dns", "")
+
+		hostnames = []
+		results = self.ldap.query(COMPUTERS_FILTER, ["name"])
+		for result in results:
+			computer_name = result["name"]
+			hostnames.append("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
+			# print only if resolution was not mandated
+			if not resolve:
+				print("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
+		# do the resolution
+		if resolve:
+			for computer in utils_resolve(hostnames, dns):
+				print("{addr:20} {name}".format(addr=computer["address"], name=computer["hostname"]))
+
+	def list_domain_policy(self, kwargs):
+		"""
+		Return the domain policy.
+		"""
+		FILETIME_TIMESTAMP_FIELDS = {
+			"lockOutObservationWindow": (60, "mins"),
+			"lockoutDuration": (60, "mins"),
+			"maxPwdAge": (86400, "days"),
+			"minPwdAge": (86400, "days"),
+			"forceLogoff": (60, "mins")
+		}
+		FIELDS_TO_PRINT = ["dc", "distinguishedName", "lockOutObservationWindow", "lockoutDuration", "lockoutThreshold", "maxPwdAge", "minPwdAge", "minPwdLength", "pwdHistoryLength", "pwdProperties"]
+		policy = self.ldap.query(DOMAIN_INFO_FILTER)
+		if policy:
+			policy = policy[0]
+			for field in FIELDS_TO_PRINT:
+				val = policy[field]
+
+				if field == "lockOutObservationWindow" and isinstance(val, timedelta):
+					val = int(val.total_seconds()) / 60
+				elif field in FILETIME_TIMESTAMP_FIELDS.keys() and type(val) == int:
+					val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
+				if field in FILETIME_TIMESTAMP_FIELDS.keys():
+					val = "%d %s" % (val, FILETIME_TIMESTAMP_FIELDS[field][1])
+
+				print("%s: %s" % (field, val))
+
+	def list_ou(self, kwargs):
+		"""
+		Return the list of organizational units with linked GPO.
+		"""
+		cn_re = re_compile("{[^}]+}")
+		results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
+		gpos = {}
+		for gpo in results:
+			gpos[gpo["cn"]] = gpo["displayName"]
+
+		results = self.ldap.query(OU_FILTER)
+		for result in results:
+			print(result["distinguishedName"])
+			if "gPLink" in result:
+				guids = cn_re.findall(result["gPLink"])
+				if len(guids) > 0:
+					print("[gPLink]")
+					print("* {}".format("\n* ".join([gpos[g] if g in gpos else g for g in guids])))
+
+	def list_gpo(self, kwargs):
+		"""
+		Return the list of Group policy objects.
+		"""
+		results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
+		for gpo in results:
+			print("{cn}: {name}".format(cn=gpo["cn"], name=gpo["displayName"]))
+
+	def list_pso(self, kwargs):
+		"""
+		List the Password Settings Objects.
+		"""
+		FILETIME_TIMESTAMP_FIELDS = {
+			"msDS-LockoutObservationWindow": (60, "mins"),
+			"msDS-MinimumPasswordAge": (86400, "days"),
+			"msDS-MaximumPasswordAge": (86400, "days"),
+			"msDS-LockoutDuration": (60, "mins")
+		}
+		FIELDS_TO_PRINT = [
+			"cn",
+			"msDS-PasswordReversibleEncryptionEnabled",
+			"msDS-PasswordSettingsPrecedence",
+			"msDS-MinimumPasswordLength",
+			"msDS-PasswordHistoryLength",
+			"msDS-PasswordComplexityEnabled",
+			"msDS-LockoutObservationWindow",
+			"msDS-LockoutDuration",
+			"msDS-LockoutThreshold",
+			"msDS-MinimumPasswordAge",
+			"msDS-MaximumPasswordAge",
+		]
+		psos = self.ldap.query(PSO_INFO_FILTER)
+		for policy in psos:
+			for field in FIELDS_TO_PRINT:
+				if isinstance(policy[field], list):
+					val = policy[field][0]
+				else:
+					val = policy[field]
+
+				if field in FILETIME_TIMESTAMP_FIELDS.keys():
+					val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
+					val = "{val} {typ}".format(val=val, typ=FILETIME_TIMESTAMP_FIELDS[field][1])
+				print("{field}: {val}".format(field=field, val=val))
+
+	def list_trusts(self, kwargs):
+		"""
+		List the domain's trust relationships.
+		"""
+		results = self.ldap.query(TRUSTS_INFO_FILTER)
+		FIELDS_TO_PRINT = ["dn", "cn", "securityIdentifier", "name", "trustDirection", "trustPartner", "trustType", "trustAttributes", "flatName"]
+		for result in results:
+			for field in FIELDS_TO_PRINT:
+				if field in result:
+					val = result[field]
+					if field == "trustDirection":
+						if int(val) == 0x00000003:
+							val = "bidirectional"
+						elif int(val) == 0x00000002:
+							val = "outbound"
+						elif int(val) == 0x00000001:
+							val = "inbound"
+						elif int(val) == 0x00000000:
+							val = "disabled"
+					elif field == "trustType":
+						if int(val) == 0x00000001:
+							val = "Non running Windows domain"
+						elif int(val) == 0x00000002:
+							val = "Windows domain running Active Directory"
+						elif int(val) == 0x00000003:
+							val = "Non Windows domain"
+					print("{field}: {val}".format(field=field, val=val))
+			print("")
+
+	def list_zones(self, kwargs):
+		"""
+		List the DNS zones configured in the Active Directory.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+		"""
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if not verbose:
+			attributes = ["dc", "objectClass"]
+		else:
+			attributes = ALL
+
+		if security:
+			attributes = attributes + ['ntSecurityDescriptor']
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		self.display(
+			self.ldap.query(
+				ZONES_FILTER,
+				attributes,
+				controls=controls,
+				base=','.join(["CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
+			),
+			verbose
+		)
+
+	# GETTERS #
+
+	def get_zone(self, kwargs):
+		"""
+		Return the records of a DNS zone.
+
+		Arguments:
+			#dns_zone:string
+				DNS zone to retrieve records
+		"""
+		dns_zone = kwargs["dns_zone"]
+		try:
+			results = self.ldap.query(
+				ZONE_FILTER,
+				base=','.join(["DC={}".format(dns_zone), "CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
+			)
+		except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+			error(e)
+		else:
+			self.display(results)
+
+	def get_membersof(self, kwargs):
+		"""
+		List the members of `group`.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#group:string
+				Group to list members
+		"""
+		group = kwargs["group"]
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		attributes = ["distinguishedName", "objectSid"]
+
+		if security:
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		results = self.ldap.query(GROUP_DN_FILTER.format(group=group), attributes)
+		if results:
+			group_dn = results[0]["distinguishedName"]
+		else:
+			error("Group {group} does not exists".format(group=group))
+
+		primary_group_id = results[0]["objectSid"].split('-')[-1]
+		results = self.ldap.query(USERS_IN_GROUP_FILTER.format(group=group_dn, primary_group_id=primary_group_id), controls=controls)
+		self.display(results, verbose)
+
+	def get_memberships(self, kwargs):
+		"""
+		List the group for which `users` belongs to.
+
+		Arguments:
+			#user:string
+				User to list memberships
+			@recursive:bool
+				List recursively the groups
+		"""
+		user = kwargs["user"]
+		recursive = kwargs.get("recursive", False)
+
+		already_printed = set()
+
+		def lookup_groups(dn, leading_sp, already_treated):
+			groups = []
+			results = self.ldap.query("(distinguishedName={})".format(dn), ["memberOf"])
+			for result in results:
+				if "memberOf" in result:
+					for group_dn in result["memberOf"]:
+						if group_dn not in already_treated:
+							print("{g:>{width}}".format(g=group_dn, width=leading_sp + len(group_dn)))
+							already_treated.add(group_dn)
+							lookup_groups(group_dn, leading_sp + 4, already_treated)
+
+			return already_treated
+
+		results = self.ldap.query(USER_IN_GROUPS_FILTER.format(username=user), ["memberOf"])
+		for result in results:
+			if "memberOf" in result:
+				for group_dn in result["memberOf"]:
+					print(group_dn)
+					if recursive:
+						already_printed.add(group_dn)
+						s = lookup_groups(group_dn, 4, already_printed)
+						already_printed.union(s)
+			else:
+				error("No groups for user {}".format(user))
+
+	def get_from_sid(self, kwargs):
+		"""
+		Return the object associated with the given `sid`.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#sid:string
+				SID to search for
+		"""
+		sid = kwargs["sid"]
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if security:
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		try:
+			result = self.ldap.resolve_sid(sid, controls=controls)
+			if isinstance(result, str):
+				print(result)
+			else:
+				self.display(result, verbose)
+		except ActiveDirectoryView.ActiveDirectoryLdapInvalidSID:
+			error("Invalid SID")
+
+	def get_from_guid(self, kwargs):
+		"""
+		Return the object associated with the given `guid`.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#guid:string
+				GUID to search for
+		"""
+		guid = kwargs["guid"]
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if security:
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		try:
+			self.display(self.ldap.resolve_guid(guid, controls=controls), verbose)
+		except ActiveDirectoryView.ActiveDirectoryLdapInvalidGUID:
+			error("Invalid GUID")
+
+	def get_object(self, kwargs):
+		"""
+		Return the records containing `object` in a CN.
+
+		Arguments:
+			@verbose:bool
+				Results will contain full information
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#object:string
+				Pattern to look for in CNs
+		"""
+		anr = kwargs["object"]
+		verbose = kwargs.get("verbose", False)
+		security = kwargs.get("security", False)
+
+		if security:
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		results = self.ldap.query("(&(anr={ldap_object}))".format(ldap_object=anr), controls=controls)
+		self.display(results, verbose)
+
+	def get_sddl(self, kwargs):
+		"""
+		Returns the SDDL of an object given it's CN.
+
+		Arguments:
+			#object:string
+				CN of object.
+		"""
+		anr = kwargs["object"]
+
+		results = self.ldap.get_sddl("(anr={ldap_object})".format(ldap_object=anr))
+
+		self.display(results, True, False)
+
+	# MISC #
+
+	def misc_search(self, kwargs):
+		"""
+		Query the LDAP with `filter` and retrieve ALL or `attributes` if specified.
+
+		Arguments:
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#filter:string
+				LDAP filter to search for
+			#attributes:string = 'ALL'
+				Comma separated list of attributes to display, ALL for every possible attribute
+		"""
+		attr = kwargs["attributes"]
+		filter_ = kwargs["filter"]
+		security = kwargs.get("security", False)
+
+		if security:
+			controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+		else:
+			controls = []
+
+		try:
+			if attr and attr != "ALL":
+				results = self.ldap.query(filter_, attr.split(","), controls=controls)
+			else:
+				results = self.ldap.query(filter_, controls=controls)
+			self.display(results, True)
+		except Exception as e:
+			error(e)
+
+	def misc_all(self, kwargs):
+		"""
+		Collect and store computers, domain_policy, zones, gpo, groups, ou, users, trusts, pso information
+
+		Arguments:
+			@security:bool
+				Results will contain full information + security descriptors on objects
+			#output:string
+				File prefix for the files that will be created during the execution
+		"""
+		output = kwargs["output"]
+		security = kwargs.get("security", False)
+		kwargs["verbose"] = False
+
+		for command, method in self.get_commands(prefix="list_"):
+			info("Retrieving {command} output".format(command=command))
+			if self.has_option(method, "filter"):
+				filter_ = self.retrieve_default_val_for_arg(method, "filter")
+				for f in filter_:
+					sys.stdout = Logger("{output}_{command}_{filter}.lst".format(output=output, command=command, filter=f), quiet=True)
+					kwargs["filter"] = f
+					getattr(self, method)(kwargs)
+
+					if self.has_option(method, "verbose"):
+						if security:
+							kwargs["security"] = True
+						info("Retrieving {command} verbose output".format(command=command))
+						sys.stdout = Logger("{output}_{command}_{filter}.json".format(output=output, command=command, filter=f), quiet=True)
+						kwargs["verbose"] = True
+						getattr(self, method)(kwargs)
+						kwargs["verbose"] = False
+						kwargs["security"] = False
+				kwargs["filter"] = None
+			else:
+				sys.stdout = Logger("{output}_{command}.lst".format(output=output, command=command), quiet=True)
+				getattr(self, method)(kwargs)
+
+				if self.has_option(method, "verbose"):
+					if security:
+						kwargs["security"] = True
+					info("Retrieving {command} verbose output".format(command=command))
+					sys.stdout = Logger("{output}_{command}.json".format(output=output, command=command), quiet=True)
+					kwargs["verbose"] = True
+					getattr(self, method)(kwargs)
+					kwargs["verbose"] = False
+					kwargs["security"] = False
+
+	# ACTION #
+
+	def action_unlock(self, kwargs):
+		"""
+		Unlock `user`.
+
+		Arguments:
+			#user:string
+				User to unlock
+		"""
+		user = kwargs["user"]
+
+		if self.ldap.unlock(user):
+			info("User {username} unlocked (or was already unlocked)".format(username=user))
+		else:
+			error("Unable to unlock {username}, check privileges".format(username=user))
+
+	def action_modify_password(self, kwargs):
+		"""
+		Change `user`'s password.
+
+		Arguments:
+			#user:string
+				User to unlock
+			#newpassword:string
+				New password
+			#currpassword:string = None
+				Current password
+		"""
+		user = kwargs["user"]
+		new = kwargs["newpassword"]
+		curr = kwargs.get("currpassword", None)
+		if curr == "None":
+			curr = None
+
+		if self.ldap.modify_password(user, curr, new):
+			info("Password of {username} changed".format(username=user))
+		else:
+			error("Unable to change {username}'s password, check privileges or try with ldaps://".format(username=user))
 
 
 def main():
-    parser = ArgumentParser()
-    parser.add_argument("-d", "--fqdn", help="The domain FQDN (ex : domain.local)", required=True)
-    parser.add_argument("-s", "--ldapserver", help="The LDAP path (ex : ldap://corp.contoso.com:389)", required=True)
-    parser.add_argument("-b", "--base", default="", help="LDAP base for query")
-    parser.add_argument("-o", "--outfile", default="", help="Store the results in a file")
+	parser = ArgumentParser()
+	parser.add_argument("-d", "--fqdn", help="The domain FQDN (ex : domain.local)", required=True)
+	parser.add_argument("-s", "--ldapserver", help="The LDAP path (ex : ldap://corp.contoso.com:389)", required=True)
+	parser.add_argument("-b", "--base", default="", help="LDAP base for query")
+	parser.add_argument("-o", "--outfile", default="", help="Store the results in a file")
 
-    ntlm = parser.add_argument_group("NTLM authentication")
-    ntlm.add_argument("-u", "--username", help="The username")
-    ntlm.add_argument("-p", "--password", help="The password or the corresponding NTLM hash")
+	ntlm = parser.add_argument_group("NTLM authentication")
+	ntlm.add_argument("-u", "--username", help="The username")
+	ntlm.add_argument("-p", "--password", help="The password or the corresponding NTLM hash")
 
-    kerberos = parser.add_argument_group("Kerberos authentication")
-    kerberos.add_argument("-k", "--kerberos", action="store_true", help="For Kerberos authentication, ticket file should be pointed by $KRB5NAME env variable")
+	kerberos = parser.add_argument_group("Kerberos authentication")
+	kerberos.add_argument("-k", "--kerberos", action="store_true", help="For Kerberos authentication, ticket file should be pointed by $KRB5NAME env variable")
 
-    anonymous = parser.add_argument_group("Anonymous authentication")
-    anonymous.add_argument("-a", "--anonymous", action="store_true", help="Perform anonymous binds")
+	anonymous = parser.add_argument_group("Anonymous authentication")
+	anonymous.add_argument("-a", "--anonymous", action="store_true", help="Perform anonymous binds")
 
-    Ldeep.add_subparsers(parser, ["list_", "get_", "misc_", "action_"], title="commands", description="available commands")
-    args = parser.parse_args()
+	Ldeep.add_subparsers(parser, ["list_", "get_", "misc_", "action_"], title="commands", description="available commands")
+	args = parser.parse_args()
 
-    # Authentication
-    method = "NTLM"
-    if args.kerberos:
-        method = "Kerberos"
-    elif args.username:
-        method = "NTLM"
-    elif args.anonymous:
-        method = "anonymous"
-    else:
-        error("Lack of authentication options: either Kerberos or Username with Password (can be a NTLM hash).")
+	# Authentication
+	method = "NTLM"
+	if args.kerberos:
+		method = "Kerberos"
+	elif args.username:
+		method = "NTLM"
+	elif args.anonymous:
+		method = "anonymous"
+	else:
+		error("Lack of authentication options: either Kerberos or Username with Password (can be a NTLM hash).")
 
-    # Output
-    if args.outfile:
-        sys.stdout = Logger(args.outfile, quiet=False)
+	# Output
+	if args.outfile:
+		sys.stdout = Logger(args.outfile, quiet=False)
 
-    # main
-    try:
-        ldap_connection = ActiveDirectoryView(args.ldapserver, args.fqdn, args.base, args.username, args.password, method)
-    except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-        error(e)
+	# main
+	try:
+		ldap_connection = ActiveDirectoryView(args.ldapserver, args.fqdn, args.base, args.username, args.password, method)
+	except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+		error(e)
 
-    ldeep = Ldeep(ldap_connection)
-    ldeep.dispatch_command(args)
+	ldeep = Ldeep(ldap_connection)
+	ldeep.dispatch_command(args)
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -19,585 +19,674 @@ import sys
 
 class Ldeep(Command):
 
-	def __init__(self, ldap_connection, format="json"):
-		try:
-			self.ldap = ldap_connection
-		except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-			error(e)
-
-		if format == "json":
-			self.__display = self.__display_json
-
-	def display(self, records, verbose=False, specify_group=True):
-		def default(o):
-			if isinstance(o, date) or isinstance(o, datetime):
-				return o.isoformat()
-			elif isinstance(o, bytes):
-				return base64.b64encode(o).decode('ascii')
-
-		if verbose:
-			self.__display(list(map(dict, records)), default)
-		else:
-			for record in records:
-				if "group" in record["objectClass"]:
-					print(record["sAMAccountName"] + (" (group)" if specify_group else ""))
-				elif "user" in record["objectClass"]:
-					print(record["sAMAccountName"])
-				elif "dnsNode" in record["objectClass"]:
-					print("{dc} {rec}".format(dc=record["dc"], rec=" ".join(record["dnsRecord"])))
-				elif "dnsZone" in record["objectClass"]:
-					print(record["dc"])
-				elif "domain" in record["objectClass"]:
-					print(record["dn"])
-
-	def __display_json(self, records, default):
-		json_dump(records, sys.stdout, ensure_ascii=False, default=default, sort_keys=True, indent=2)
-
-	# LISTERS #
-
-	def list_users(self, kwargs):
-		"""
-		List users according to a filter.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-			@filter:string = ["all", "spn", "enabled", "disabled", "locked", "nopasswordexpire", "passwordexpired", "nokrbpreauth", "reversible"]
-		"""
-		verbose = kwargs.get("verbose", False)
-		filter_ = kwargs.get("filter", "all")
-
-		if verbose:
-			attributes = ALL
-		else:
-			attributes = ["samAccountName", "objectClass"]
-
-		if filter_ == "all":
-			results = self.ldap.query(USER_ALL_FILTER, attributes)
-		elif filter_ == "spn":
-			results = self.ldap.query(USER_SPN_FILTER, attributes)
-		elif filter_ == "enabled":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER_NEG.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes)
-		elif filter_ == "disabled":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes)
-		elif filter_ == "locked":
-			results = self.ldap.query(USER_LOCKED_FILTER, attributes)
-		elif filter_ == "nopasswordexpire":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_EXPIRE_PASSWORD"]), attributes)
-		elif filter_ == "passwordexpired":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["PASSWORD_EXPIRED"]), attributes)
-		elif filter_ == "nokrbpreauth":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_REQ_PREAUTH"]), attributes)
-		elif filter_ == "reversible":
-			results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ENCRYPTED_TEXT_PWD_ALLOWED"]), attributes)
-		else:
-			return None
-
-		self.display(results, verbose)
-
-	def list_groups(self, kwargs):
-		"""
-		List the groups.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-		"""
-		verbose = kwargs.get("verbose", False)
-
-		if not verbose:
-			attributes = ["samAccountName", "objectClass"]
-		else:
-			attributes = ALL
-
-		self.display(self.ldap.query(GROUPS_FILTER, attributes), verbose, specify_group=False)
-
-	def list_machines(self, kwargs):
-		"""
-		List the machine accounts.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-		"""
-		verbose = kwargs.get("verbose", False)
-
-		if not verbose:
-			attributes = ["samAccountName", "objectClass"]
-		else:
-			attributes = ALL
-
-		self.display(self.ldap.query(COMPUTERS_FILTER, attributes), verbose, specify_group=False)
-
-	def list_computers(self, kwargs):
-		"""
-		List the computer hostnames and resolve them if --resolve is specify.
-
-		Arguments:
-			@resolve:bool
-				A resolution on all computer names will be performed
-			@dns:string
-				An optional DNS server to use for the resolution
-		"""
-		resolve = "resolve" in kwargs and kwargs["resolve"]
-		dns = kwargs.get("dns", "")
-
-		hostnames = []
-		results = self.ldap.query(COMPUTERS_FILTER, ["name"])
-		for result in results:
-			computer_name = result["name"]
-			hostnames.append("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
-			# print only if resolution was not mandated
-			if not resolve:
-				print("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
-		# do the resolution
-		if resolve:
-			for computer in utils_resolve(hostnames, dns):
-				print("{addr:20} {name}".format(addr=computer["address"], name=computer["hostname"]))
-
-	def list_domain_policy(self, kwargs):
-		"""
-		Return the domain policy.
-		"""
-		FILETIME_TIMESTAMP_FIELDS = {
-			"lockOutObservationWindow": (60, "mins"),
-			"lockoutDuration": (60, "mins"),
-			"maxPwdAge": (86400, "days"),
-			"minPwdAge": (86400, "days"),
-			"forceLogoff": (60, "mins")
-		}
-		FIELDS_TO_PRINT = ["dc", "distinguishedName", "lockOutObservationWindow", "lockoutDuration", "lockoutThreshold", "maxPwdAge", "minPwdAge", "minPwdLength", "pwdHistoryLength", "pwdProperties"]
-		policy = self.ldap.query(DOMAIN_INFO_FILTER)
-		if policy:
-			policy = policy[0]
-			for field in FIELDS_TO_PRINT:
-				val = policy[field]
-
-				if field == "lockOutObservationWindow" and isinstance(val, timedelta):
-					val = int(val.total_seconds()) / 60
-				elif field in FILETIME_TIMESTAMP_FIELDS.keys() and type(val) == int:
-					val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
-				if field in FILETIME_TIMESTAMP_FIELDS.keys():
-					val = "%d %s" % (val, FILETIME_TIMESTAMP_FIELDS[field][1])
-
-				print("%s: %s" % (field, val))
-
-	def list_ou(self, kwargs):
-		"""
-		Return the list of organizational units with linked GPO.
-		"""
-		cn_re = re_compile("{[^}]+}")
-		results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
-		gpos = {}
-		for gpo in results:
-			gpos[gpo["cn"]] = gpo["displayName"]
-
-		results = self.ldap.query(OU_FILTER)
-		for result in results:
-			print(result["distinguishedName"])
-			if "gPLink" in result:
-				guids = cn_re.findall(result["gPLink"])
-				if len(guids) > 0:
-					print("[gPLink]")
-					print("* {}".format("\n* ".join([gpos[g] if g in gpos else g for g in guids])))
-
-	def list_gpo(self, kwargs):
-		"""
-		Return the list of Group policy objects.
-		"""
-		results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
-		for gpo in results:
-			print("{cn}: {name}".format(cn=gpo["cn"], name=gpo["displayName"]))
-
-	def list_pso(self, kwargs):
-		"""
-		List the Password Settings Objects.
-		"""
-		FILETIME_TIMESTAMP_FIELDS = {
-			"msDS-LockoutObservationWindow": (60, "mins"),
-			"msDS-MinimumPasswordAge": (86400, "days"),
-			"msDS-MaximumPasswordAge": (86400, "days"),
-			"msDS-LockoutDuration": (60, "mins")
-		}
-		FIELDS_TO_PRINT = [
-			"cn",
-			"msDS-PasswordReversibleEncryptionEnabled",
-			"msDS-PasswordSettingsPrecedence",
-			"msDS-MinimumPasswordLength",
-			"msDS-PasswordHistoryLength",
-			"msDS-PasswordComplexityEnabled",
-			"msDS-LockoutObservationWindow",
-			"msDS-LockoutDuration",
-			"msDS-LockoutThreshold",
-			"msDS-MinimumPasswordAge",
-			"msDS-MaximumPasswordAge",
-		]
-		psos = self.ldap.query(PSO_INFO_FILTER)
-		for policy in psos:
-			for field in FIELDS_TO_PRINT:
-				if isinstance(policy[field], list):
-					val = policy[field][0]
-				else:
-					val = policy[field]
-
-				if field in FILETIME_TIMESTAMP_FIELDS.keys():
-					val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
-					val = "{val} {typ}".format(val=val, typ=FILETIME_TIMESTAMP_FIELDS[field][1])
-				print("{field}: {val}".format(field=field, val=val))
-
-	def list_trusts(self, kwargs):
-		"""
-		List the domain's trust relationships.
-		"""
-		results = self.ldap.query(TRUSTS_INFO_FILTER)
-		FIELDS_TO_PRINT = ["dn", "cn", "securityIdentifier", "name", "trustDirection", "trustPartner", "trustType", "trustAttributes", "flatName"]
-		for result in results:
-			for field in FIELDS_TO_PRINT:
-				if field in result:
-					val = result[field]
-					if field == "trustDirection":
-						if int(val) == 0x00000003:
-							val = "bidirectional"
-						elif int(val) == 0x00000002:
-							val = "outbound"
-						elif int(val) == 0x00000001:
-							val = "inbound"
-						elif int(val) == 0x00000000:
-							val = "disabled"
-					elif field == "trustType":
-						if int(val) == 0x00000001:
-							val = "Non running Windows domain"
-						elif int(val) == 0x00000002:
-							val = "Windows domain running Active Directory"
-						elif int(val) == 0x00000003:
-							val = "Non Windows domain"
-					print("{field}: {val}".format(field=field, val=val))
-			print("")
-
-	def list_zones(self, kwargs):
-		"""
-		List the DNS zones configured in the Active Directory.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-		"""
-		verbose = kwargs.get("verbose", False)
-
-		if not verbose:
-			attributes = ["dc", "objectClass"]
-		else:
-			attributes = ALL
-
-		self.display(
-			self.ldap.query(
-				ZONES_FILTER,
-				attributes, base=','.join(["CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
-			),
-			verbose
-		)
-
-	# GETTERS #
-
-	def get_zone(self, kwargs):
-		"""
-		Return the records of a DNS zone.
-
-		Arguments:
-			#dns_zone:string
-				DNS zone to retrieve records
-		"""
-		dns_zone = kwargs["dns_zone"]
-		try:
-			results = self.ldap.query(
-				ZONE_FILTER,
-				base=','.join(["DC={}".format(dns_zone), "CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
-			)
-		except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-			error(e)
-		else:
-			self.display(results)
-
-	def get_membersof(self, kwargs):
-		"""
-		List the members of `group`.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-			#group:string
-				Group to list members
-		"""
-		group = kwargs["group"]
-		verbose = kwargs.get("verbose", False)
-
-		results = self.ldap.query(GROUP_DN_FILTER.format(group=group), ["distinguishedName", "objectSid"])
-		if results:
-			group_dn = results[0]["distinguishedName"]
-		else:
-			error("Group {group} does not exists".format(group=group))
-
-		primary_group_id = results[0]["objectSid"].split('-')[-1]
-		results = self.ldap.query(USERS_IN_GROUP_FILTER.format(group=group_dn, primary_group_id=primary_group_id))
-		self.display(results, verbose)
-
-	def get_memberships(self, kwargs):
-		"""
-		List the group for which `users` belongs to.
-
-		Arguments:
-			#user:string
-				User to list memberships
-			@recursive:bool
-				List recursively the groups
-		"""
-		user = kwargs["user"]
-		recursive = kwargs.get("recursive", False)
-
-		already_printed = set()
-
-		def lookup_groups(dn, leading_sp, already_treated):
-			groups = []
-			results = self.ldap.query("(distinguishedName={})".format(dn), ["memberOf"])
-			for result in results:
-				if "memberOf" in result:
-					for group_dn in result["memberOf"]:
-						if group_dn not in already_treated:
-							print("{g:>{width}}".format(g=group_dn, width=leading_sp + len(group_dn)))
-							already_treated.add(group_dn)
-							lookup_groups(group_dn, leading_sp + 4, already_treated)
-
-			return already_treated
-
-		results = self.ldap.query(USER_IN_GROUPS_FILTER.format(username=user), ["memberOf"])
-		for result in results:
-			if "memberOf" in result:
-				for group_dn in result["memberOf"]:
-					print(group_dn)
-					if recursive:
-						already_printed.add(group_dn)
-						s = lookup_groups(group_dn, 4, already_printed)
-						already_printed.union(s)
-			else:
-				error("No groups for user {}".format(user))
-
-	def get_from_sid(self, kwargs):
-		"""
-		Return the object associated with the given `sid`.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-			#sid:string
-				SID to search for
-		"""
-		sid = kwargs["sid"]
-		verbose = kwargs.get("verbose", False)
-
-		try:
-			result = self.ldap.resolve_sid(sid)
-			if isinstance(result, str):
-				print(result)
-			else:
-				self.display(result, verbose)
-		except ActiveDirectoryView.ActiveDirectoryLdapInvalidSID:
-			error("Invalid SID")
-
-	def get_from_guid(self, kwargs):
-		"""
-		Return the object associated with the given `guid`.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-			#guid:string
-				GUID to search for
-		"""
-		guid = kwargs["guid"]
-		verbose = kwargs.get("verbose", False)
-
-		try:
-			self.display(self.ldap.resolve_guid(guid), verbose)
-		except ActiveDirectoryView.ActiveDirectoryLdapInvalidGUID:
-			error("Invalid GUID")
-
-	def get_object(self, kwargs):
-		"""
-		Return the records containing `object` in a CN.
-
-		Arguments:
-			@verbose:bool
-				Results will contain full information
-			#object:string
-				Pattern to look for in CNs
-		"""
-		anr = kwargs["object"]
-		verbose = kwargs.get("verbose", False)
-
-		results = self.ldap.query("(&(anr={ldap_object}))".format(ldap_object=anr))
-		self.display(results, verbose)
-
-	def get_sddl(self, kwargs):
-		"""
-		Returns the SDDL of an object given it's CN.
-
-		Arguments:
-			#object:string
-				CN of object.
-		"""
-		anr = kwargs["object"]
-
-		results = self.ldap.get_sddl("(anr={ldap_object})".format(ldap_object=anr))
-
-		self.display(results, True, False)
-
-	# MISC #
-
-	def misc_search(self, kwargs):
-		"""
-		Query the LDAP with `filter` and retrieve ALL or `attributes` if specified.
-
-		Arguments:
-			#filter:string
-				LDAP filter to search for
-			#attributes:string = 'ALL'
-				Comma separated list of attributes to display, ALL for every possible attribute
-		"""
-		attr = kwargs["attributes"]
-		filter_ = kwargs["filter"]
-
-		try:
-			if attr and attr != "ALL":
-				results = self.ldap.query(filter_, attr.split(","))
-			else:
-				results = self.ldap.query(filter_)
-			self.display(results, True)
-		except Exception as e:
-			error(e)
-
-	def misc_all(self, kwargs):
-		"""
-		Collect and store computers, domain_policy, zones, gpo, groups, ou, users, trusts, pso information
-
-		Arguments:
-			#output:string
-				File prefix for the files that will be created during the execution
-		"""
-		output = kwargs["output"]
-		kwargs["verbose"] = False
-
-		for command, method in self.get_commands(prefix="list_"):
-			info("Retrieving {command} output".format(command=command))
-			if self.has_option(method, "filter"):
-				filter_ = self.retrieve_default_val_for_arg(method, "filter")
-				for f in filter_:
-					sys.stdout = Logger("{output}_{command}_{filter}.lst".format(output=output, command=command, filter=f), quiet=True)
-					kwargs["filter"] = f
-					getattr(self, method)(kwargs)
-
-					if self.has_option(method, "verbose"):
-						info("Retrieving {command} verbose output".format(command=command))
-						sys.stdout = Logger("{output}_{command}_{filter}.json".format(output=output, command=command, filter=f), quiet=True)
-						kwargs["verbose"] = True
-						getattr(self, method)(kwargs)
-						kwargs["verbose"] = False
-				kwargs["filter"] = None
-			else:
-				sys.stdout = Logger("{output}_{command}.lst".format(output=output, command=command), quiet=True)
-				getattr(self, method)(kwargs)
-
-				if self.has_option(method, "verbose"):
-					info("Retrieving {command} verbose output".format(command=command))
-					sys.stdout = Logger("{output}_{command}.json".format(output=output, command=command), quiet=True)
-					kwargs["verbose"] = True
-					getattr(self, method)(kwargs)
-					kwargs["verbose"] = False
-
-	# ACTION #
-
-	def action_unlock(self, kwargs):
-		"""
-		Unlock `user`.
-
-		Arguments:
-			#user:string
-				User to unlock
-		"""
-		user = kwargs["user"]
-
-		if self.ldap.unlock(user):
-			info("User {username} unlocked (or was already unlocked)".format(username=user))
-		else:
-			error("Unable to unlock {username}, check privileges".format(username=user))
-
-	def action_modify_password(self, kwargs):
-		"""
-		Change `user`'s password.
-
-		Arguments:
-			#user:string
-				User to unlock
-			#newpassword:string
-				New password
-			#currpassword:string = None
-				Current password
-		"""
-		user = kwargs["user"]
-		new = kwargs["newpassword"]
-		curr = kwargs.get("currpassword", None)
-		if curr == "None":
-			curr = None
-
-		if self.ldap.modify_password(user, curr, new):
-			info("Password of {username} changed".format(username=user))
-		else:
-			error("Unable to change {username}'s password, check privileges or try with ldaps://".format(username=user))
+    def __init__(self, ldap_connection, format="json"):
+        try:
+            self.ldap = ldap_connection
+        except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+            error(e)
+
+        if format == "json":
+            self.__display = self.__display_json
+
+    def display(self, records, verbose=False, specify_group=True):
+        def default(o):
+            if isinstance(o, date) or isinstance(o, datetime):
+                return o.isoformat()
+            elif isinstance(o, bytes):
+                return base64.b64encode(o).decode('ascii')
+
+        if verbose:
+            self.__display(list(map(dict, records)), default)
+        else:
+            for record in records:
+                if "group" in record["objectClass"]:
+                    print(record["sAMAccountName"] + (" (group)" if specify_group else ""))
+                elif "user" in record["objectClass"]:
+                    print(record["sAMAccountName"])
+                elif "dnsNode" in record["objectClass"]:
+                    print("{dc} {rec}".format(dc=record["dc"], rec=" ".join(record["dnsRecord"])))
+                elif "dnsZone" in record["objectClass"]:
+                    print(record["dc"])
+                elif "domain" in record["objectClass"]:
+                    print(record["dn"])
+
+    def __display_json(self, records, default):
+        json_dump(records, sys.stdout, ensure_ascii=False, default=default, sort_keys=True, indent=2)
+
+    # LISTERS #
+
+    def list_users(self, kwargs):
+        """
+        List users according to a filter.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            @filter:string = ["all", "spn", "enabled", "disabled", "locked", "nopasswordexpire", "passwordexpired", "nokrbpreauth", "reversible"]
+        """
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+        filter_ = kwargs.get("filter", "all")
+
+        if verbose:
+            attributes = ALL
+        else:
+            attributes = ["samAccountName", "objectClass"]
+
+        if security:
+            attributes = attributes + ['ntSecurityDescriptor']
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        if filter_ == "all":
+            results = self.ldap.query(USER_ALL_FILTER, attributes, controls=controls)
+        elif filter_ == "spn":
+            results = self.ldap.query(USER_SPN_FILTER, attributes, controls=controls)
+        elif filter_ == "enabled":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER_NEG.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
+        elif filter_ == "disabled":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ACCOUNTDISABLE"]), attributes, controls=controls)
+        elif filter_ == "locked":
+            results = self.ldap.query(USER_LOCKED_FILTER, attributes, controls=controls)
+        elif filter_ == "nopasswordexpire":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_EXPIRE_PASSWORD"]), attributes, controls=controls)
+        elif filter_ == "passwordexpired":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["PASSWORD_EXPIRED"]), attributes, controls=controls)
+        elif filter_ == "nokrbpreauth":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["DONT_REQ_PREAUTH"]), attributes, controls=controls)
+        elif filter_ == "reversible":
+            results = self.ldap.query(USER_ACCOUNT_CONTROL_FILTER.format(intval=USER_ACCOUNT_CONTROL["ENCRYPTED_TEXT_PWD_ALLOWED"]), attributes, controls=controls)
+        else:
+            return None
+
+        self.display(results, verbose)
+
+    def list_groups(self, kwargs):
+        """
+        List the groups.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+        """
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if not verbose:
+            attributes = ["samAccountName", "objectClass"]
+        else:
+            attributes = ALL
+
+        if security:
+            attributes = attributes + ['ntSecurityDescriptor']
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        self.display(self.ldap.query(GROUPS_FILTER, attributes, controls=controls), verbose, specify_group=False)
+
+    def list_machines(self, kwargs):
+        """
+        List the machine accounts.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+        """
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if not verbose:
+            attributes = ["samAccountName", "objectClass"]
+        else:
+            attributes = ALL
+
+        if security:
+            attributes = attributes + ['ntSecurityDescriptor']
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        self.display(self.ldap.query(COMPUTERS_FILTER, attributes, controls=controls), verbose, specify_group=False)
+
+    def list_computers(self, kwargs):
+        """
+        List the computer hostnames and resolve them if --resolve is specify.
+
+        Arguments:
+            @resolve:bool
+                A resolution on all computer names will be performed
+            @dns:string
+                An optional DNS server to use for the resolution
+        """
+        resolve = "resolve" in kwargs and kwargs["resolve"]
+        dns = kwargs.get("dns", "")
+
+        hostnames = []
+        results = self.ldap.query(COMPUTERS_FILTER, ["name"])
+        for result in results:
+            computer_name = result["name"]
+            hostnames.append("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
+            # print only if resolution was not mandated
+            if not resolve:
+                print("{hostname}.{fqdn}".format(hostname=computer_name, fqdn=self.ldap.fqdn))
+        # do the resolution
+        if resolve:
+            for computer in utils_resolve(hostnames, dns):
+                print("{addr:20} {name}".format(addr=computer["address"], name=computer["hostname"]))
+
+    def list_domain_policy(self, kwargs):
+        """
+        Return the domain policy.
+        """
+        FILETIME_TIMESTAMP_FIELDS = {
+            "lockOutObservationWindow": (60, "mins"),
+            "lockoutDuration": (60, "mins"),
+            "maxPwdAge": (86400, "days"),
+            "minPwdAge": (86400, "days"),
+            "forceLogoff": (60, "mins")
+        }
+        FIELDS_TO_PRINT = ["dc", "distinguishedName", "lockOutObservationWindow", "lockoutDuration", "lockoutThreshold", "maxPwdAge", "minPwdAge", "minPwdLength", "pwdHistoryLength", "pwdProperties"]
+        policy = self.ldap.query(DOMAIN_INFO_FILTER)
+        if policy:
+            policy = policy[0]
+            for field in FIELDS_TO_PRINT:
+                val = policy[field]
+
+                if field == "lockOutObservationWindow" and isinstance(val, timedelta):
+                    val = int(val.total_seconds()) / 60
+                elif field in FILETIME_TIMESTAMP_FIELDS.keys() and type(val) == int:
+                    val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
+                if field in FILETIME_TIMESTAMP_FIELDS.keys():
+                    val = "%d %s" % (val, FILETIME_TIMESTAMP_FIELDS[field][1])
+
+                print("%s: %s" % (field, val))
+
+    def list_ou(self, kwargs):
+        """
+        Return the list of organizational units with linked GPO.
+        """
+        cn_re = re_compile("{[^}]+}")
+        results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
+        gpos = {}
+        for gpo in results:
+            gpos[gpo["cn"]] = gpo["displayName"]
+
+        results = self.ldap.query(OU_FILTER)
+        for result in results:
+            print(result["distinguishedName"])
+            if "gPLink" in result:
+                guids = cn_re.findall(result["gPLink"])
+                if len(guids) > 0:
+                    print("[gPLink]")
+                    print("* {}".format("\n* ".join([gpos[g] if g in gpos else g for g in guids])))
+
+    def list_gpo(self, kwargs):
+        """
+        Return the list of Group policy objects.
+        """
+        results = self.ldap.query(GPO_INFO_FILTER, ["cn", "displayName"])
+        for gpo in results:
+            print("{cn}: {name}".format(cn=gpo["cn"], name=gpo["displayName"]))
+
+    def list_pso(self, kwargs):
+        """
+        List the Password Settings Objects.
+        """
+        FILETIME_TIMESTAMP_FIELDS = {
+            "msDS-LockoutObservationWindow": (60, "mins"),
+            "msDS-MinimumPasswordAge": (86400, "days"),
+            "msDS-MaximumPasswordAge": (86400, "days"),
+            "msDS-LockoutDuration": (60, "mins")
+        }
+        FIELDS_TO_PRINT = [
+            "cn",
+            "msDS-PasswordReversibleEncryptionEnabled",
+            "msDS-PasswordSettingsPrecedence",
+            "msDS-MinimumPasswordLength",
+            "msDS-PasswordHistoryLength",
+            "msDS-PasswordComplexityEnabled",
+            "msDS-LockoutObservationWindow",
+            "msDS-LockoutDuration",
+            "msDS-LockoutThreshold",
+            "msDS-MinimumPasswordAge",
+            "msDS-MaximumPasswordAge",
+        ]
+        psos = self.ldap.query(PSO_INFO_FILTER)
+        for policy in psos:
+            for field in FIELDS_TO_PRINT:
+                if isinstance(policy[field], list):
+                    val = policy[field][0]
+                else:
+                    val = policy[field]
+
+                if field in FILETIME_TIMESTAMP_FIELDS.keys():
+                    val = int((fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0])
+                    val = "{val} {typ}".format(val=val, typ=FILETIME_TIMESTAMP_FIELDS[field][1])
+                print("{field}: {val}".format(field=field, val=val))
+
+    def list_trusts(self, kwargs):
+        """
+        List the domain's trust relationships.
+        """
+        results = self.ldap.query(TRUSTS_INFO_FILTER)
+        FIELDS_TO_PRINT = ["dn", "cn", "securityIdentifier", "name", "trustDirection", "trustPartner", "trustType", "trustAttributes", "flatName"]
+        for result in results:
+            for field in FIELDS_TO_PRINT:
+                if field in result:
+                    val = result[field]
+                    if field == "trustDirection":
+                        if int(val) == 0x00000003:
+                            val = "bidirectional"
+                        elif int(val) == 0x00000002:
+                            val = "outbound"
+                        elif int(val) == 0x00000001:
+                            val = "inbound"
+                        elif int(val) == 0x00000000:
+                            val = "disabled"
+                    elif field == "trustType":
+                        if int(val) == 0x00000001:
+                            val = "Non running Windows domain"
+                        elif int(val) == 0x00000002:
+                            val = "Windows domain running Active Directory"
+                        elif int(val) == 0x00000003:
+                            val = "Non Windows domain"
+                    print("{field}: {val}".format(field=field, val=val))
+            print("")
+
+    def list_zones(self, kwargs):
+        """
+        List the DNS zones configured in the Active Directory.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+        """
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if not verbose:
+            attributes = ["dc", "objectClass"]
+        else:
+            attributes = ALL
+
+        if security:
+            attributes = attributes + ['ntSecurityDescriptor']
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        self.display(
+            self.ldap.query(
+                ZONES_FILTER,
+                attributes,
+                controls=controls,
+                base=','.join(["CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
+            ),
+            verbose
+        )
+
+    # GETTERS #
+
+    def get_zone(self, kwargs):
+        """
+        Return the records of a DNS zone.
+
+        Arguments:
+            #dns_zone:string
+                DNS zone to retrieve records
+        """
+        dns_zone = kwargs["dns_zone"]
+        try:
+            results = self.ldap.query(
+                ZONE_FILTER,
+                base=','.join(["DC={}".format(dns_zone), "CN=MicrosoftDNS,DC=DomainDNSZones", self.ldap.base_dn])
+            )
+        except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+            error(e)
+        else:
+            self.display(results)
+
+    def get_membersof(self, kwargs):
+        """
+        List the members of `group`.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #group:string
+                Group to list members
+        """
+        group = kwargs["group"]
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        attributes = ["distinguishedName", "objectSid"]
+
+        if security:
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        results = self.ldap.query(GROUP_DN_FILTER.format(group=group), attributes)
+        if results:
+            group_dn = results[0]["distinguishedName"]
+        else:
+            error("Group {group} does not exists".format(group=group))
+
+        primary_group_id = results[0]["objectSid"].split('-')[-1]
+        results = self.ldap.query(USERS_IN_GROUP_FILTER.format(group=group_dn, primary_group_id=primary_group_id), controls=controls)
+        self.display(results, verbose)
+
+    def get_memberships(self, kwargs):
+        """
+        List the group for which `users` belongs to.
+
+        Arguments:
+            #user:string
+                User to list memberships
+            @recursive:bool
+                List recursively the groups
+        """
+        user = kwargs["user"]
+        recursive = kwargs.get("recursive", False)
+
+        already_printed = set()
+
+        def lookup_groups(dn, leading_sp, already_treated):
+            groups = []
+            results = self.ldap.query("(distinguishedName={})".format(dn), ["memberOf"])
+            for result in results:
+                if "memberOf" in result:
+                    for group_dn in result["memberOf"]:
+                        if group_dn not in already_treated:
+                            print("{g:>{width}}".format(g=group_dn, width=leading_sp + len(group_dn)))
+                            already_treated.add(group_dn)
+                            lookup_groups(group_dn, leading_sp + 4, already_treated)
+
+            return already_treated
+
+        results = self.ldap.query(USER_IN_GROUPS_FILTER.format(username=user), ["memberOf"])
+        for result in results:
+            if "memberOf" in result:
+                for group_dn in result["memberOf"]:
+                    print(group_dn)
+                    if recursive:
+                        already_printed.add(group_dn)
+                        s = lookup_groups(group_dn, 4, already_printed)
+                        already_printed.union(s)
+            else:
+                error("No groups for user {}".format(user))
+
+    def get_from_sid(self, kwargs):
+        """
+        Return the object associated with the given `sid`.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #sid:string
+                SID to search for
+        """
+        sid = kwargs["sid"]
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if security:
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        try:
+            result = self.ldap.resolve_sid(sid, controls=controls)
+            if isinstance(result, str):
+                print(result)
+            else:
+                self.display(result, verbose)
+        except ActiveDirectoryView.ActiveDirectoryLdapInvalidSID:
+            error("Invalid SID")
+
+    def get_from_guid(self, kwargs):
+        """
+        Return the object associated with the given `guid`.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #guid:string
+                GUID to search for
+        """
+        guid = kwargs["guid"]
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if security:
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        try:
+            self.display(self.ldap.resolve_guid(guid, controls=controls), verbose)
+        except ActiveDirectoryView.ActiveDirectoryLdapInvalidGUID:
+            error("Invalid GUID")
+
+    def get_object(self, kwargs):
+        """
+        Return the records containing `object` in a CN.
+
+        Arguments:
+            @verbose:bool
+                Results will contain full information
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #object:string
+                Pattern to look for in CNs
+        """
+        anr = kwargs["object"]
+        verbose = kwargs.get("verbose", False)
+        security = kwargs.get("security", False)
+
+        if security:
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        results = self.ldap.query("(&(anr={ldap_object}))".format(ldap_object=anr), controls=controls)
+        self.display(results, verbose)
+
+    def get_sddl(self, kwargs):
+        """
+        Returns the SDDL of an object given it's CN.
+
+        Arguments:
+            #object:string
+                CN of object.
+        """
+        anr = kwargs["object"]
+
+        results = self.ldap.get_sddl("(anr={ldap_object})".format(ldap_object=anr))
+
+        self.display(results, True, False)
+
+    # MISC #
+
+    def misc_search(self, kwargs):
+        """
+        Query the LDAP with `filter` and retrieve ALL or `attributes` if specified.
+
+        Arguments:
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #filter:string
+                LDAP filter to search for
+            #attributes:string = 'ALL'
+                Comma separated list of attributes to display, ALL for every possible attribute
+        """
+        attr = kwargs["attributes"]
+        filter_ = kwargs["filter"]
+        security = kwargs.get("security", False)
+
+        if security:
+            controls = [('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+        else:
+            controls = []
+
+        try:
+            if attr and attr != "ALL":
+                results = self.ldap.query(filter_, attr.split(","), controls=controls)
+            else:
+                results = self.ldap.query(filter_, controls=controls)
+            self.display(results, True)
+        except Exception as e:
+            error(e)
+
+    def misc_all(self, kwargs):
+        """
+        Collect and store computers, domain_policy, zones, gpo, groups, ou, users, trusts, pso information
+
+        Arguments:
+            @security:bool
+                Results will contain full information + security descriptors on objects
+            #output:string
+                File prefix for the files that will be created during the execution
+        """
+        output = kwargs["output"]
+        security = kwargs.get("security", False)
+        kwargs["verbose"] = False
+
+        for command, method in self.get_commands(prefix="list_"):
+            info("Retrieving {command} output".format(command=command))
+            if self.has_option(method, "filter"):
+                filter_ = self.retrieve_default_val_for_arg(method, "filter")
+                for f in filter_:
+                    sys.stdout = Logger("{output}_{command}_{filter}.lst".format(output=output, command=command, filter=f), quiet=True)
+                    kwargs["filter"] = f
+                    getattr(self, method)(kwargs)
+
+                    if self.has_option(method, "verbose"):
+                        if security:
+                            kwargs["security"] = True
+                        info("Retrieving {command} verbose output".format(command=command))
+                        sys.stdout = Logger("{output}_{command}_{filter}.json".format(output=output, command=command, filter=f), quiet=True)
+                        kwargs["verbose"] = True
+                        getattr(self, method)(kwargs)
+                        kwargs["verbose"] = False
+                        kwargs["security"] = False
+                kwargs["filter"] = None
+            else:
+                sys.stdout = Logger("{output}_{command}.lst".format(output=output, command=command), quiet=True)
+                getattr(self, method)(kwargs)
+
+                if self.has_option(method, "verbose"):
+                    if security:
+                        kwargs["security"] = True
+                    info("Retrieving {command} verbose output".format(command=command))
+                    sys.stdout = Logger("{output}_{command}.json".format(output=output, command=command), quiet=True)
+                    kwargs["verbose"] = True
+                    getattr(self, method)(kwargs)
+                    kwargs["verbose"] = False
+                    kwargs["security"] = False
+
+    # ACTION #
+
+    def action_unlock(self, kwargs):
+        """
+        Unlock `user`.
+
+        Arguments:
+            #user:string
+                User to unlock
+        """
+        user = kwargs["user"]
+
+        if self.ldap.unlock(user):
+            info("User {username} unlocked (or was already unlocked)".format(username=user))
+        else:
+            error("Unable to unlock {username}, check privileges".format(username=user))
+
+    def action_modify_password(self, kwargs):
+        """
+        Change `user`'s password.
+
+        Arguments:
+            #user:string
+                User to unlock
+            #newpassword:string
+                New password
+            #currpassword:string = None
+                Current password
+        """
+        user = kwargs["user"]
+        new = kwargs["newpassword"]
+        curr = kwargs.get("currpassword", None)
+        if curr == "None":
+            curr = None
+
+        if self.ldap.modify_password(user, curr, new):
+            info("Password of {username} changed".format(username=user))
+        else:
+            error("Unable to change {username}'s password, check privileges or try with ldaps://".format(username=user))
 
 
 def main():
-	parser = ArgumentParser()
-	parser.add_argument("-d", "--fqdn", help="The domain FQDN (ex : domain.local)", required=True)
-	parser.add_argument("-s", "--ldapserver", help="The LDAP path (ex : ldap://corp.contoso.com:389)", required=True)
-	parser.add_argument("-b", "--base", default="", help="LDAP base for query")
-	parser.add_argument("-o", "--outfile", default="", help="Store the results in a file")
+    parser = ArgumentParser()
+    parser.add_argument("-d", "--fqdn", help="The domain FQDN (ex : domain.local)", required=True)
+    parser.add_argument("-s", "--ldapserver", help="The LDAP path (ex : ldap://corp.contoso.com:389)", required=True)
+    parser.add_argument("-b", "--base", default="", help="LDAP base for query")
+    parser.add_argument("-o", "--outfile", default="", help="Store the results in a file")
 
-	ntlm = parser.add_argument_group("NTLM authentication")
-	ntlm.add_argument("-u", "--username", help="The username")
-	ntlm.add_argument("-p", "--password", help="The password or the corresponding NTLM hash")
+    ntlm = parser.add_argument_group("NTLM authentication")
+    ntlm.add_argument("-u", "--username", help="The username")
+    ntlm.add_argument("-p", "--password", help="The password or the corresponding NTLM hash")
 
-	kerberos = parser.add_argument_group("Kerberos authentication")
-	kerberos.add_argument("-k", "--kerberos", action="store_true", help="For Kerberos authentication, ticket file should be pointed by $KRB5NAME env variable")
+    kerberos = parser.add_argument_group("Kerberos authentication")
+    kerberos.add_argument("-k", "--kerberos", action="store_true", help="For Kerberos authentication, ticket file should be pointed by $KRB5NAME env variable")
 
-	anonymous = parser.add_argument_group("Anonymous authentication")
-	anonymous.add_argument("-a", "--anonymous", action="store_true", help="Perform anonymous binds")
+    anonymous = parser.add_argument_group("Anonymous authentication")
+    anonymous.add_argument("-a", "--anonymous", action="store_true", help="Perform anonymous binds")
 
-	Ldeep.add_subparsers(parser, ["list_", "get_", "misc_", "action_"], title="commands", description="available commands")
-	args = parser.parse_args()
+    Ldeep.add_subparsers(parser, ["list_", "get_", "misc_", "action_"], title="commands", description="available commands")
+    args = parser.parse_args()
 
-	# Authentication
-	method = "NTLM"
-	if args.kerberos:
-		method = "Kerberos"
-	elif args.username:
-		method = "NTLM"
-	elif args.anonymous:
-		method = "anonymous"
-	else:
-		error("Lack of authentication options: either Kerberos or Username with Password (can be a NTLM hash).")
+    # Authentication
+    method = "NTLM"
+    if args.kerberos:
+        method = "Kerberos"
+    elif args.username:
+        method = "NTLM"
+    elif args.anonymous:
+        method = "anonymous"
+    else:
+        error("Lack of authentication options: either Kerberos or Username with Password (can be a NTLM hash).")
 
-	# Output
-	if args.outfile:
-		sys.stdout = Logger(args.outfile, quiet=False)
+    # Output
+    if args.outfile:
+        sys.stdout = Logger(args.outfile, quiet=False)
 
-	# main
-	try:
-		ldap_connection = ActiveDirectoryView(args.ldapserver, args.fqdn, args.base, args.username, args.password, method)
-	except ActiveDirectoryView.ActiveDirectoryLdapException as e:
-		error(e)
+    # main
+    try:
+        ldap_connection = ActiveDirectoryView(args.ldapserver, args.fqdn, args.base, args.username, args.password, method)
+    except ActiveDirectoryView.ActiveDirectoryLdapException as e:
+        error(e)
 
-	ldeep = Ldeep(ldap_connection)
-	ldeep.dispatch_command(args)
+    ldeep = Ldeep(ldap_connection)
+    ldeep.dispatch_command(args)
 
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/ldeep/ldap/activedirectory.py
+++ b/ldeep/ldap/activedirectory.py
@@ -21,82 +21,82 @@ ALL = [ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES]
 
 # define an ldap3-compliant formatters
 def format_userAccountControl(raw_value):
-	try:
-		val = int(raw_value)
-		result = []
-		for k, v in USER_ACCOUNT_CONTROL.items():
-			if v & val:
-				result.append(k)
-		return " | ".join(result)
-	except (TypeError, ValueError):  # expected exceptions↲
-		pass
-	except Exception:  # any other exception should be investigated, anyway the formatters return the raw_value
-		pass
-	return raw_value
+    try:
+        val = int(raw_value)
+        result = []
+        for k, v in USER_ACCOUNT_CONTROL.items():
+            if v & val:
+                result.append(k)
+        return " | ".join(result)
+    except (TypeError, ValueError):  # expected exceptions↲
+        pass
+    except Exception:  # any other exception should be investigated, anyway the formatters return the raw_value
+        pass
+    return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_samAccountType(raw_value):
-	try:
-		val = int(raw_value)
-		result = []
-		for k, v in SAM_ACCOUNT_TYPE.items():
-			if v & val:
-				result.append(k)
-		return " | ".join(result)
-	except (TypeError, ValueError):  # expected exceptions↲
-		pass
-	except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
-		pass
-	return raw_value
+    try:
+        val = int(raw_value)
+        result = []
+        for k, v in SAM_ACCOUNT_TYPE.items():
+            if v & val:
+                result.append(k)
+        return " | ".join(result)
+    except (TypeError, ValueError):  # expected exceptions↲
+        pass
+    except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
+        pass
+    return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_pwdProperties(raw_value):
-	try:
-		val = int(raw_value)
-		result = []
-		for k, v in PWD_PROPERTIES.items():
-			if v & val:
-				result.append(k)
-		return " | ".join(result)
-	except (TypeError, ValueError):  # expected exceptions↲
-		pass
-	except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
-		pass
-	return raw_value
+    try:
+        val = int(raw_value)
+        result = []
+        for k, v in PWD_PROPERTIES.items():
+            if v & val:
+                result.append(k)
+        return " | ".join(result)
+    except (TypeError, ValueError):  # expected exceptions↲
+        pass
+    except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
+        pass
+    return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_dnsrecord(raw_value):
-	databytes = raw_value[0:4]
-	datalen, datatype = unpack("HH", databytes)
-	data = raw_value[24:24 + datalen]
-	for recordname, recordvalue in DNS_TYPES.items():
-		if recordvalue == datatype:
-			if recordname == "A":
-				target = inet_ntoa(data)
-			else:
-				# how, ugly
-				data = data.decode('unicode-escape')
-				target = ''.join([c for c in data if ord(c) > 31 or ord(c) == 9])
-			return "%s %s" % (recordname, target)
+    databytes = raw_value[0:4]
+    datalen, datatype = unpack("HH", databytes)
+    data = raw_value[24:24 + datalen]
+    for recordname, recordvalue in DNS_TYPES.items():
+        if recordvalue == datatype:
+            if recordname == "A":
+                target = inet_ntoa(data)
+            else:
+                # how, ugly
+                data = data.decode('unicode-escape')
+                target = ''.join([c for c in data if ord(c) > 31 or ord(c) == 9])
+            return "%s %s" % (recordname, target)
 
 def format_ad_timedelta(raw_value):
-	"""
-	Convert a negative filetime value to an integer timedelta.
-	"""
-	if isinstance(raw_value, bytes):
-		raw_value = int(raw_value)
-	return raw_value
+    """
+    Convert a negative filetime value to an integer timedelta.
+    """
+    if isinstance(raw_value, bytes):
+        raw_value = int(raw_value)
+    return raw_value
 
 def format_ad_timedelta(raw_value):
-	"""
-	Convert a negative filetime value to an integer timedelta.
-	"""
-	if isinstance(raw_value, bytes):
-		raw_value = int(raw_value)
-	return raw_value
+    """
+    Convert a negative filetime value to an integer timedelta.
+    """
+    if isinstance(raw_value, bytes):
+        raw_value = int(raw_value)
+    return raw_value
 
 
 ldap3.protocol.formatters.standard.standard_formatter["1.2.840.113556.1.4.8"] = (format_userAccountControl, None)
@@ -111,207 +111,213 @@ ldap3.protocol.formatters.standard.standard_formatter['1.2.840.113556.1.4.78'] =
 ldap3.protocol.formatters.standard.standard_formatter['1.2.840.113556.1.2.281'] = (parse_ntSecurityDescriptor, None)
 
 class ActiveDirectoryView(object):
-	"""
-	Manage a LDAP connection to a LDAP Active Directory.
-	"""
+    """
+    Manage a LDAP connection to a LDAP Active Directory.
+    """
 
-	class ActiveDirectoryLdapException(Exception):
-		pass
+    class ActiveDirectoryLdapException(Exception):
+        pass
 
-	class ActiveDirectoryLdapInvalidSID(Exception):
-		pass
+    class ActiveDirectoryLdapInvalidSID(Exception):
+        pass
 
-	class ActiveDirectoryLdapInvalidGUID(Exception):
-		pass
+    class ActiveDirectoryLdapInvalidGUID(Exception):
+        pass
 
-	def __init__(self, server, fqdn, base="", username="", password="", method="NTLM"):
-		"""
-		ActiveDirectoryView constructor.
-		Initialize the connection with the LDAP server.
+    def __init__(self, server, fqdn, base="", username="", password="", method="NTLM"):
+        """
+        ActiveDirectoryView constructor.
+        Initialize the connection with the LDAP server.
 
-		Two authentication modes:
-			* Kerberos (ldap3 will automatically retrieve the $KRB5CCNAME env variable)
-			* NTLM (username + password or NTLM hash)
+        Two authentication modes:
+            * Kerberos (ldap3 will automatically retrieve the $KRB5CCNAME env variable)
+            * NTLM (username + password or NTLM hash)
 
-		@server: Server to connect and perform LDAP query to.
-		@fqdn: Fully qualified domain name of the Active Directory domain.
-		@base: Base for the LDAP queries.
-		@username: Username to use for the authentication (for NTLM authentication)
-		@password: Username to use for the authentication (for NTLM authentication)
-		@method: Either to use NTLM, Kerberos or anonymous authentication.
+        @server: Server to connect and perform LDAP query to.
+        @fqdn: Fully qualified domain name of the Active Directory domain.
+        @base: Base for the LDAP queries.
+        @username: Username to use for the authentication (for NTLM authentication)
+        @password: Username to use for the authentication (for NTLM authentication)
+        @method: Either to use NTLM, Kerberos or anonymous authentication.
 
-		@throw ActiveDirectoryLdapException when the connection or the bind does not work.
-		"""
-		self.username = username
-		self.password = password
-		self.server = server
-		self.fqdn = fqdn
-		self.hostnames = []
+        @throw ActiveDirectoryLdapException when the connection or the bind does not work.
+        """
+        self.username = username
+        self.password = password
+        self.server = server
+        self.fqdn = fqdn
+        self.hostnames = []
 
-		if self.server.startswith("ldaps"):
-			server = Server(
-				self.server,
-				port=636,
-				use_ssl=True,
-				allowed_referral_hosts=[('*', True)],
-				tls=ldap3.Tls(validate=CERT_NONE)
-			)
-		else:
-			server = Server(self.server)
+        if self.server.startswith("ldaps"):
+            server = Server(
+                self.server,
+                port=636,
+                use_ssl=True,
+                allowed_referral_hosts=[('*', True)],
+                tls=ldap3.Tls(validate=CERT_NONE)
+            )
+        else:
+            server = Server(self.server)
 
-		if method == "Kerberos":
-			self.ldap = Connection(server, authentication=SASL, sasl_mechanism=KERBEROS)
-		if method == "anonymous":
-			self.ldap = Connection(server)
-		elif method == "NTLM":
-			self.ldap = Connection(
-				server,
-				user="{domain}\\{username}".format(domain=fqdn, username=username),
-				password=password,
-				authentication=NTLM, check_names=True
-			)
+        if method == "Kerberos":
+            self.ldap = Connection(server, authentication=SASL, sasl_mechanism=KERBEROS)
+        if method == "anonymous":
+            self.ldap = Connection(server)
+        elif method == "NTLM":
+            self.ldap = Connection(
+                server,
+                user="{domain}\\{username}".format(domain=fqdn, username=username),
+                password=password,
+                authentication=NTLM, check_names=True
+            )
+        if not self.ldap.bind():
+            raise self.ActiveDirectoryLdapException("Unable to bind with provided information")
 
-		if not self.ldap.bind():
-			raise self.ActiveDirectoryLdapException("Unable to bind with provided information")
+        if not "." in fqdn:
+            self.base_dn = base or "".join(["dc={}".format(d) for d in self.ldap.request['base'].split("DC=")[1:]])
+        else:
+            self.base_dn = base or ','.join(["dc={}".format(d) for d in fqdn.split(".")])
+        self.search_scope = SUBTREE
 
-		self.base_dn = base or ','.join(["dc={}".format(d) for d in fqdn.split(".")])
-		self.search_scope = SUBTREE
+    def query(self, ldapfilter, attributes=[ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES], base=None, scope=None, controls=None):
+        """
+        Perform a query to the LDAP server and return the results.
 
-	def query(self, ldapfilter, attributes=[ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES], base=None, scope=None):
-		"""
-		Perform a query to the LDAP server and return the results.
+        @ldapfiler: The LDAP filter to query (see RFC 2254).
+        @attributes: List of attributes to retrieved with the query.
+        @base: Base to use during the request.
+        @scope: Scope to use during the request.
+        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-		@ldapfiler: The LDAP filter to query (see RFC 2254).
-		@attributes: List of attributes to retrieved with the query.
-		@base: Base to use during the request.
-		@scope: Scope to use during the request.
+        @return a list of records.
+        """
+        result_set = []
+        try:
+            entry_generator = self.ldap.extend.standard.paged_search(
+                search_base=base or self.base_dn,
+                search_filter=ldapfilter,
+                search_scope=scope or self.search_scope,
+                attributes=attributes,
+                controls=controls,
+                paged_size=PAGE_SIZE,
+                generator=True
+            )
 
-		@return a list of records.
-		"""
-		result_set = []
-		try:
-			entry_generator = self.ldap.extend.standard.paged_search(
-				search_base=base or self.base_dn,
-				search_filter=ldapfilter,
-				search_scope=scope or self.search_scope,
-				attributes=attributes,
-				paged_size=PAGE_SIZE,
-				generator=True
-			)
+            for entry in entry_generator:
+                if "dn" in entry:
+                    d = entry["attributes"]
+                    d["dn"] = entry["dn"]
+                    result_set.append(d)
 
-			for entry in entry_generator:
-				if "dn" in entry:
-					d = entry["attributes"]
-					d["dn"] = entry["dn"]
-					result_set.append(d)
+        except LDAPOperationResult as e:
+            raise self.ActiveDirectoryLdapException(e)
 
-		except LDAPOperationResult as e:
-			raise self.ActiveDirectoryLdapException(e)
+        return result_set
 
-		return result_set
+    def resolve_sid(self, sid, controls=None):
+        """
+        Two cases:
+            * the SID is a WELL KNOWN SID and a local SID, the name of the corresponding account is returned;
+            * else, the SID is search through the LDAP and the corresponding record is returned.
 
-	def resolve_sid(self, sid):
-		"""
-		Two cases:
-			* the SID is a WELL KNOWN SID and a local SID, the name of the corresponding account is returned;
-			* else, the SID is search through the LDAP and the corresponding record is returned.
+        @sid: the sid to search for.
+        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-		@sid: the sid to search for.
+        @throw ActiveDirectoryLdapInvalidSID if the SID is not a valid SID.
+        @return the record corresponding to the SID queried.
+        """
+        if sid in WELL_KNOWN_SIDs:
+            return WELL_KNOWN_SIDs[sid]
+        elif validate_sid(sid):
+            results = self.query("(&(ObjectSid={sid}))".format(sid=sid), controls=controls)
+            if results:
+                return results
+        raise self.ActiveDirectoryLdapInvalidSID("SID: {sid}".format(sid=sid))
 
-		@throw ActiveDirectoryLdapInvalidSID if the SID is not a valid SID.
-		@return the record corresponding to the SID queried.
-		"""
-		if sid in WELL_KNOWN_SIDs:
-			return WELL_KNOWN_SIDs[sid]
-		elif validate_sid(sid):
-			results = self.query("(&(ObjectSid={sid}))".format(sid=sid))
-			if results:
-				return results
-		raise self.ActiveDirectoryLdapInvalidSID("SID: {sid}".format(sid=sid))
+    def resolve_guid(self, guid, controls=None):
+        """
+        Return the LDAP record with the provided GUID.
 
-	def resolve_guid(self, guid):
-		"""
-		Return the LDAP record with the provided GUID.
+        @guid: the guid to search for.
+        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-		@guid: the guid to search for.
+        @throw ActiveDirectoryLdapInvalidGUID if the GUID is not a valid GUID.
+        @return the record corresponding to the guid queried.
+        """
+        if validate_guid(guid):
+            results = self.query("(&(ObjectGUID={guid}))".format(guid=guid), controls=controls)
+            # Normally only one result should have been retrieved:
+            if results:
+                return results
+        raise self.ActiveDirectoryLdapInvalidGUID("GUID: {guid}".format(guid=guid))
 
-		@throw ActiveDirectoryLdapInvalidGUID if the GUID is not a valid GUID.
-		@return the record corresponding to the guid queried.
-		"""
-		if validate_guid(guid):
-			results = self.query("(&(ObjectGUID={guid}))".format(guid=guid))
-			# Normally only one result should have been retrieved:
-			if results:
-				return results
-		raise self.ActiveDirectoryLdapInvalidGUID("GUID: {guid}".format(guid=guid))
+    def get_sddl(self, ldapfilter, base=None, scope=None):
+        """
+        Perform a query to the LDAP server and return the results.
 
-	def get_sddl(self, ldapfilter, base=None, scope=None):
-		"""
-		Perform a query to the LDAP server and return the results.
+        @ldapfiler: The LDAP filter to query (see RFC 2254).
+        @attributes: List of attributes to retrieved with the query.
+        @base: Base to use during the request.
+        @scope: Scope to use during the request.
 
-		@ldapfiler: The LDAP filter to query (see RFC 2254).
-		@attributes: List of attributes to retrieved with the query.
-		@base: Base to use during the request.
-		@scope: Scope to use during the request.
+        @return a list of records.
+        """
+        result_set = []
+        try:
+            result = self.ldap.search(
+                search_base=base or self.base_dn,
+                search_filter=ldapfilter,
+                search_scope=scope or self.search_scope,
+                attributes=['ntSecurityDescriptor'],
+                controls=[('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+            )
 
-		@return a list of records.
-		"""
-		result_set = []
-		try:
-			result = self.ldap.search(
-				search_base=base or self.base_dn,
-				search_filter=ldapfilter,
-				search_scope=scope or self.search_scope,
-				attributes=['ntSecurityDescriptor'],
-				controls=[('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-			)
+            if not result:
+                raise self.ActiveDirectoryLdapException()
+            else:
+                for entry in self.ldap.response:
+                    if "dn" in entry:
+                        d = entry["attributes"]
+                        d["dn"] = entry["dn"]
+                        result_set.append(d)
 
-			if not result:
-				raise self.ActiveDirectoryLdapException()
-			else:
-				for entry in self.ldap.response:
-					if "dn" in entry:
-						d = entry["attributes"]
-						d["dn"] = entry["dn"]
-						result_set.append(d)
+        except LDAPOperationResult as e:
+            raise self.ActiveDirectoryLdapException(e)
 
-		except LDAPOperationResult as e:
-			raise self.ActiveDirectoryLdapException(e)
+        return result_set
 
-		return result_set
+    def unlock(self, username):
+        """
+        Unlock an account.
 
-	def unlock(self, username):
-		"""
-		Unlock an account.
+        @username: the username associated to the account to unlock.
 
-		@username: the username associated to the account to unlock.
+        @throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
+        @return True if the account was successfully unlock or False otherwise.
+        """
+        results = self.query(USER_DN_FILTER.format(username=username))
+        if len(results) != 1:
+            raise ActiveDirectoryLdapException("Zero or non uniq result")
+        else:
+            user = results[0]
+            unlock = ad_unlock_account(self.ldap, user["dn"])
+            # goddamn, return value is either True or str...
+            return isinstance(unlock, bool)
 
-		@throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
-		@return True if the account was successfully unlock or False otherwise.
-		"""
-		results = self.query(USER_DN_FILTER.format(username=username))
-		if len(results) != 1:
-			raise ActiveDirectoryLdapException("Zero or non uniq result")
-		else:
-			user = results[0]
-			unlock = ad_unlock_account(self.ldap, user["dn"])
-			# goddamn, return value is either True or str...
-			return isinstance(unlock, bool)
+    def modify_password(self, username, oldpassword, newpassword):
+        """
+        Change the password of `username`.
 
-	def modify_password(self, username, oldpassword, newpassword):
-		"""
-		Change the password of `username`.
+        @username: the username associated to the account to modify its password.
+        @newpassword: the new password to apply.
+        @oldpassword: the old password.
 
-		@username: the username associated to the account to modify its password.
-		@newpassword: the new password to apply.
-		@oldpassword: the old password.
-
-		@throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
-		@return True if the account was successfully unlock or False otherwise.
-		"""
-		results = self.query(USER_DN_FILTER.format(username=username))
-		if len(results) != 1:
-			raise ActiveDirectoryLdapException("Zero or non uniq result")
-		else:
-			user = results[0]
-			return ad_modify_password(self.ldap, user["dn"], newpassword, None)
+        @throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
+        @return True if the account was successfully unlock or False otherwise.
+        """
+        results = self.query(USER_DN_FILTER.format(username=username))
+        if len(results) != 1:
+            raise ActiveDirectoryLdapException("Zero or non uniq result")
+        else:
+            user = results[0]
+            return ad_modify_password(self.ldap, user["dn"], newpassword, None)

--- a/ldeep/ldap/activedirectory.py
+++ b/ldeep/ldap/activedirectory.py
@@ -21,82 +21,82 @@ ALL = [ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES]
 
 # define an ldap3-compliant formatters
 def format_userAccountControl(raw_value):
-    try:
-        val = int(raw_value)
-        result = []
-        for k, v in USER_ACCOUNT_CONTROL.items():
-            if v & val:
-                result.append(k)
-        return " | ".join(result)
-    except (TypeError, ValueError):  # expected exceptions↲
-        pass
-    except Exception:  # any other exception should be investigated, anyway the formatters return the raw_value
-        pass
-    return raw_value
+	try:
+		val = int(raw_value)
+		result = []
+		for k, v in USER_ACCOUNT_CONTROL.items():
+			if v & val:
+				result.append(k)
+		return " | ".join(result)
+	except (TypeError, ValueError):  # expected exceptions↲
+		pass
+	except Exception:  # any other exception should be investigated, anyway the formatters return the raw_value
+		pass
+	return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_samAccountType(raw_value):
-    try:
-        val = int(raw_value)
-        result = []
-        for k, v in SAM_ACCOUNT_TYPE.items():
-            if v & val:
-                result.append(k)
-        return " | ".join(result)
-    except (TypeError, ValueError):  # expected exceptions↲
-        pass
-    except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
-        pass
-    return raw_value
+	try:
+		val = int(raw_value)
+		result = []
+		for k, v in SAM_ACCOUNT_TYPE.items():
+			if v & val:
+				result.append(k)
+		return " | ".join(result)
+	except (TypeError, ValueError):  # expected exceptions↲
+		pass
+	except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
+		pass
+	return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_pwdProperties(raw_value):
-    try:
-        val = int(raw_value)
-        result = []
-        for k, v in PWD_PROPERTIES.items():
-            if v & val:
-                result.append(k)
-        return " | ".join(result)
-    except (TypeError, ValueError):  # expected exceptions↲
-        pass
-    except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
-        pass
-    return raw_value
+	try:
+		val = int(raw_value)
+		result = []
+		for k, v in PWD_PROPERTIES.items():
+			if v & val:
+				result.append(k)
+		return " | ".join(result)
+	except (TypeError, ValueError):  # expected exceptions↲
+		pass
+	except Exception:  # any other exception should be investigated, anyway the formatter returns the raw_value
+		pass
+	return raw_value
 
 
 # define an ldap3-compliant formatters
 def format_dnsrecord(raw_value):
-    databytes = raw_value[0:4]
-    datalen, datatype = unpack("HH", databytes)
-    data = raw_value[24:24 + datalen]
-    for recordname, recordvalue in DNS_TYPES.items():
-        if recordvalue == datatype:
-            if recordname == "A":
-                target = inet_ntoa(data)
-            else:
-                # how, ugly
-                data = data.decode('unicode-escape')
-                target = ''.join([c for c in data if ord(c) > 31 or ord(c) == 9])
-            return "%s %s" % (recordname, target)
+	databytes = raw_value[0:4]
+	datalen, datatype = unpack("HH", databytes)
+	data = raw_value[24:24 + datalen]
+	for recordname, recordvalue in DNS_TYPES.items():
+		if recordvalue == datatype:
+			if recordname == "A":
+				target = inet_ntoa(data)
+			else:
+				# how, ugly
+				data = data.decode('unicode-escape')
+				target = ''.join([c for c in data if ord(c) > 31 or ord(c) == 9])
+			return "%s %s" % (recordname, target)
 
 def format_ad_timedelta(raw_value):
-    """
-    Convert a negative filetime value to an integer timedelta.
-    """
-    if isinstance(raw_value, bytes):
-        raw_value = int(raw_value)
-    return raw_value
+	"""
+	Convert a negative filetime value to an integer timedelta.
+	"""
+	if isinstance(raw_value, bytes):
+		raw_value = int(raw_value)
+	return raw_value
 
 def format_ad_timedelta(raw_value):
-    """
-    Convert a negative filetime value to an integer timedelta.
-    """
-    if isinstance(raw_value, bytes):
-        raw_value = int(raw_value)
-    return raw_value
+	"""
+	Convert a negative filetime value to an integer timedelta.
+	"""
+	if isinstance(raw_value, bytes):
+		raw_value = int(raw_value)
+	return raw_value
 
 
 ldap3.protocol.formatters.standard.standard_formatter["1.2.840.113556.1.4.8"] = (format_userAccountControl, None)
@@ -111,213 +111,213 @@ ldap3.protocol.formatters.standard.standard_formatter['1.2.840.113556.1.4.78'] =
 ldap3.protocol.formatters.standard.standard_formatter['1.2.840.113556.1.2.281'] = (parse_ntSecurityDescriptor, None)
 
 class ActiveDirectoryView(object):
-    """
-    Manage a LDAP connection to a LDAP Active Directory.
-    """
+	"""
+	Manage a LDAP connection to a LDAP Active Directory.
+	"""
 
-    class ActiveDirectoryLdapException(Exception):
-        pass
+	class ActiveDirectoryLdapException(Exception):
+		pass
 
-    class ActiveDirectoryLdapInvalidSID(Exception):
-        pass
+	class ActiveDirectoryLdapInvalidSID(Exception):
+		pass
 
-    class ActiveDirectoryLdapInvalidGUID(Exception):
-        pass
+	class ActiveDirectoryLdapInvalidGUID(Exception):
+		pass
 
-    def __init__(self, server, fqdn, base="", username="", password="", method="NTLM"):
-        """
-        ActiveDirectoryView constructor.
-        Initialize the connection with the LDAP server.
+	def __init__(self, server, fqdn, base="", username="", password="", method="NTLM"):
+		"""
+		ActiveDirectoryView constructor.
+		Initialize the connection with the LDAP server.
 
-        Two authentication modes:
-            * Kerberos (ldap3 will automatically retrieve the $KRB5CCNAME env variable)
-            * NTLM (username + password or NTLM hash)
+		Two authentication modes:
+			* Kerberos (ldap3 will automatically retrieve the $KRB5CCNAME env variable)
+			* NTLM (username + password or NTLM hash)
 
-        @server: Server to connect and perform LDAP query to.
-        @fqdn: Fully qualified domain name of the Active Directory domain.
-        @base: Base for the LDAP queries.
-        @username: Username to use for the authentication (for NTLM authentication)
-        @password: Username to use for the authentication (for NTLM authentication)
-        @method: Either to use NTLM, Kerberos or anonymous authentication.
+		@server: Server to connect and perform LDAP query to.
+		@fqdn: Fully qualified domain name of the Active Directory domain.
+		@base: Base for the LDAP queries.
+		@username: Username to use for the authentication (for NTLM authentication)
+		@password: Username to use for the authentication (for NTLM authentication)
+		@method: Either to use NTLM, Kerberos or anonymous authentication.
 
-        @throw ActiveDirectoryLdapException when the connection or the bind does not work.
-        """
-        self.username = username
-        self.password = password
-        self.server = server
-        self.fqdn = fqdn
-        self.hostnames = []
+		@throw ActiveDirectoryLdapException when the connection or the bind does not work.
+		"""
+		self.username = username
+		self.password = password
+		self.server = server
+		self.fqdn = fqdn
+		self.hostnames = []
 
-        if self.server.startswith("ldaps"):
-            server = Server(
-                self.server,
-                port=636,
-                use_ssl=True,
-                allowed_referral_hosts=[('*', True)],
-                tls=ldap3.Tls(validate=CERT_NONE)
-            )
-        else:
-            server = Server(self.server)
+		if self.server.startswith("ldaps"):
+			server = Server(
+				self.server,
+				port=636,
+				use_ssl=True,
+				allowed_referral_hosts=[('*', True)],
+				tls=ldap3.Tls(validate=CERT_NONE)
+			)
+		else:
+			server = Server(self.server)
 
-        if method == "Kerberos":
-            self.ldap = Connection(server, authentication=SASL, sasl_mechanism=KERBEROS)
-        if method == "anonymous":
-            self.ldap = Connection(server)
-        elif method == "NTLM":
-            self.ldap = Connection(
-                server,
-                user="{domain}\\{username}".format(domain=fqdn, username=username),
-                password=password,
-                authentication=NTLM, check_names=True
-            )
-        if not self.ldap.bind():
-            raise self.ActiveDirectoryLdapException("Unable to bind with provided information")
+		if method == "Kerberos":
+			self.ldap = Connection(server, authentication=SASL, sasl_mechanism=KERBEROS)
+		if method == "anonymous":
+			self.ldap = Connection(server)
+		elif method == "NTLM":
+			self.ldap = Connection(
+				server,
+				user="{domain}\\{username}".format(domain=fqdn, username=username),
+				password=password,
+				authentication=NTLM, check_names=True
+			)
+		if not self.ldap.bind():
+			raise self.ActiveDirectoryLdapException("Unable to bind with provided information {}\\{}:{}".format(fqdn, username, password))
 
-        if not "." in fqdn:
-            self.base_dn = base or "".join(["dc={}".format(d) for d in self.ldap.request['base'].split("DC=")[1:]])
-        else:
-            self.base_dn = base or ','.join(["dc={}".format(d) for d in fqdn.split(".")])
-        self.search_scope = SUBTREE
+		if not "." in fqdn:
+			self.base_dn = base or "".join(["dc={}".format(d) for d in self.ldap.request['base'].split("DC=")[1:]])
+		else:
+			self.base_dn = base or ','.join(["dc={}".format(d) for d in fqdn.split(".")])
+		self.search_scope = SUBTREE
 
-    def query(self, ldapfilter, attributes=[ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES], base=None, scope=None, controls=None):
-        """
-        Perform a query to the LDAP server and return the results.
+	def query(self, ldapfilter, attributes=[ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES], base=None, scope=None, controls=None):
+		"""
+		Perform a query to the LDAP server and return the results.
 
-        @ldapfiler: The LDAP filter to query (see RFC 2254).
-        @attributes: List of attributes to retrieved with the query.
-        @base: Base to use during the request.
-        @scope: Scope to use during the request.
-        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
+		@ldapfiler: The LDAP filter to query (see RFC 2254).
+		@attributes: List of attributes to retrieved with the query.
+		@base: Base to use during the request.
+		@scope: Scope to use during the request.
+		@controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-        @return a list of records.
-        """
-        result_set = []
-        try:
-            entry_generator = self.ldap.extend.standard.paged_search(
-                search_base=base or self.base_dn,
-                search_filter=ldapfilter,
-                search_scope=scope or self.search_scope,
-                attributes=attributes,
-                controls=controls,
-                paged_size=PAGE_SIZE,
-                generator=True
-            )
+		@return a list of records.
+		"""
+		result_set = []
+		try:
+			entry_generator = self.ldap.extend.standard.paged_search(
+				search_base=base or self.base_dn,
+				search_filter=ldapfilter,
+				search_scope=scope or self.search_scope,
+				attributes=attributes,
+				controls=controls,
+				paged_size=PAGE_SIZE,
+				generator=True
+			)
 
-            for entry in entry_generator:
-                if "dn" in entry:
-                    d = entry["attributes"]
-                    d["dn"] = entry["dn"]
-                    result_set.append(d)
+			for entry in entry_generator:
+				if "dn" in entry:
+					d = entry["attributes"]
+					d["dn"] = entry["dn"]
+					result_set.append(d)
 
-        except LDAPOperationResult as e:
-            raise self.ActiveDirectoryLdapException(e)
+		except LDAPOperationResult as e:
+			raise self.ActiveDirectoryLdapException(e)
 
-        return result_set
+		return result_set
 
-    def resolve_sid(self, sid, controls=None):
-        """
-        Two cases:
-            * the SID is a WELL KNOWN SID and a local SID, the name of the corresponding account is returned;
-            * else, the SID is search through the LDAP and the corresponding record is returned.
+	def resolve_sid(self, sid, controls=None):
+		"""
+		Two cases:
+			* the SID is a WELL KNOWN SID and a local SID, the name of the corresponding account is returned;
+			* else, the SID is search through the LDAP and the corresponding record is returned.
 
-        @sid: the sid to search for.
-        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
+		@sid: the sid to search for.
+		@controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-        @throw ActiveDirectoryLdapInvalidSID if the SID is not a valid SID.
-        @return the record corresponding to the SID queried.
-        """
-        if sid in WELL_KNOWN_SIDs:
-            return WELL_KNOWN_SIDs[sid]
-        elif validate_sid(sid):
-            results = self.query("(&(ObjectSid={sid}))".format(sid=sid), controls=controls)
-            if results:
-                return results
-        raise self.ActiveDirectoryLdapInvalidSID("SID: {sid}".format(sid=sid))
+		@throw ActiveDirectoryLdapInvalidSID if the SID is not a valid SID.
+		@return the record corresponding to the SID queried.
+		"""
+		if sid in WELL_KNOWN_SIDs:
+			return WELL_KNOWN_SIDs[sid]
+		elif validate_sid(sid):
+			results = self.query("(&(ObjectSid={sid}))".format(sid=sid), controls=controls)
+			if results:
+				return results
+		raise self.ActiveDirectoryLdapInvalidSID("SID: {sid}".format(sid=sid))
 
-    def resolve_guid(self, guid, controls=None):
-        """
-        Return the LDAP record with the provided GUID.
+	def resolve_guid(self, guid, controls=None):
+		"""
+		Return the LDAP record with the provided GUID.
 
-        @guid: the guid to search for.
-        @controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
+		@guid: the guid to search for.
+		@controls: LDAP_SERVER_SD_FLAGS_OID flag to query various security descriptor
 
-        @throw ActiveDirectoryLdapInvalidGUID if the GUID is not a valid GUID.
-        @return the record corresponding to the guid queried.
-        """
-        if validate_guid(guid):
-            results = self.query("(&(ObjectGUID={guid}))".format(guid=guid), controls=controls)
-            # Normally only one result should have been retrieved:
-            if results:
-                return results
-        raise self.ActiveDirectoryLdapInvalidGUID("GUID: {guid}".format(guid=guid))
+		@throw ActiveDirectoryLdapInvalidGUID if the GUID is not a valid GUID.
+		@return the record corresponding to the guid queried.
+		"""
+		if validate_guid(guid):
+			results = self.query("(&(ObjectGUID={guid}))".format(guid=guid), controls=controls)
+			# Normally only one result should have been retrieved:
+			if results:
+				return results
+		raise self.ActiveDirectoryLdapInvalidGUID("GUID: {guid}".format(guid=guid))
 
-    def get_sddl(self, ldapfilter, base=None, scope=None):
-        """
-        Perform a query to the LDAP server and return the results.
+	def get_sddl(self, ldapfilter, base=None, scope=None):
+		"""
+		Perform a query to the LDAP server and return the results.
 
-        @ldapfiler: The LDAP filter to query (see RFC 2254).
-        @attributes: List of attributes to retrieved with the query.
-        @base: Base to use during the request.
-        @scope: Scope to use during the request.
+		@ldapfiler: The LDAP filter to query (see RFC 2254).
+		@attributes: List of attributes to retrieved with the query.
+		@base: Base to use during the request.
+		@scope: Scope to use during the request.
 
-        @return a list of records.
-        """
-        result_set = []
-        try:
-            result = self.ldap.search(
-                search_base=base or self.base_dn,
-                search_filter=ldapfilter,
-                search_scope=scope or self.search_scope,
-                attributes=['ntSecurityDescriptor'],
-                controls=[('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
-            )
+		@return a list of records.
+		"""
+		result_set = []
+		try:
+			result = self.ldap.search(
+				search_base=base or self.base_dn,
+				search_filter=ldapfilter,
+				search_scope=scope or self.search_scope,
+				attributes=['ntSecurityDescriptor'],
+				controls=[('1.2.840.113556.1.4.801', True, b'\x30\x03\x02\x01\x07')]
+			)
 
-            if not result:
-                raise self.ActiveDirectoryLdapException()
-            else:
-                for entry in self.ldap.response:
-                    if "dn" in entry:
-                        d = entry["attributes"]
-                        d["dn"] = entry["dn"]
-                        result_set.append(d)
+			if not result:
+				raise self.ActiveDirectoryLdapException()
+			else:
+				for entry in self.ldap.response:
+					if "dn" in entry:
+						d = entry["attributes"]
+						d["dn"] = entry["dn"]
+						result_set.append(d)
 
-        except LDAPOperationResult as e:
-            raise self.ActiveDirectoryLdapException(e)
+		except LDAPOperationResult as e:
+			raise self.ActiveDirectoryLdapException(e)
 
-        return result_set
+		return result_set
 
-    def unlock(self, username):
-        """
-        Unlock an account.
+	def unlock(self, username):
+		"""
+		Unlock an account.
 
-        @username: the username associated to the account to unlock.
+		@username: the username associated to the account to unlock.
 
-        @throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
-        @return True if the account was successfully unlock or False otherwise.
-        """
-        results = self.query(USER_DN_FILTER.format(username=username))
-        if len(results) != 1:
-            raise ActiveDirectoryLdapException("Zero or non uniq result")
-        else:
-            user = results[0]
-            unlock = ad_unlock_account(self.ldap, user["dn"])
-            # goddamn, return value is either True or str...
-            return isinstance(unlock, bool)
+		@throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
+		@return True if the account was successfully unlock or False otherwise.
+		"""
+		results = self.query(USER_DN_FILTER.format(username=username))
+		if len(results) != 1:
+			raise ActiveDirectoryLdapException("Zero or non uniq result")
+		else:
+			user = results[0]
+			unlock = ad_unlock_account(self.ldap, user["dn"])
+			# goddamn, return value is either True or str...
+			return isinstance(unlock, bool)
 
-    def modify_password(self, username, oldpassword, newpassword):
-        """
-        Change the password of `username`.
+	def modify_password(self, username, oldpassword, newpassword):
+		"""
+		Change the password of `username`.
 
-        @username: the username associated to the account to modify its password.
-        @newpassword: the new password to apply.
-        @oldpassword: the old password.
+		@username: the username associated to the account to modify its password.
+		@newpassword: the new password to apply.
+		@oldpassword: the old password.
 
-        @throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
-        @return True if the account was successfully unlock or False otherwise.
-        """
-        results = self.query(USER_DN_FILTER.format(username=username))
-        if len(results) != 1:
-            raise ActiveDirectoryLdapException("Zero or non uniq result")
-        else:
-            user = results[0]
-            return ad_modify_password(self.ldap, user["dn"], newpassword, None)
+		@throw ActiveDirectoryLdapException if the account does not exist or the query returns more than one result.
+		@return True if the account was successfully unlock or False otherwise.
+		"""
+		results = self.query(USER_DN_FILTER.format(username=username))
+		if len(results) != 1:
+			raise ActiveDirectoryLdapException("Zero or non uniq result")
+		else:
+			user = results[0]
+			return ad_modify_password(self.ldap, user["dn"], newpassword, None)


### PR DESCRIPTION
The is a first PR in order to get information from ACEs: new option --security, it will add information when the verbose option is selected (for example -vs).
```
$ PYTHONPATH=. python ldeep/__main__.py machines -h
usage: __main__.py machines [-h] [-v] [-s]

optional arguments:
  -h, --help      show this help message and exit
  -v, --verbose   Results will contain full information
  -s, --security  Results will contain full information + security descriptors on objects
```
This pull request also permit users to specify domain's NetBIOS name in the command line.