### PR TITLE
Add SIMPLE bind authentication

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -584,7 +584,8 @@ def main():
 
 	ntlm = ldap.add_argument_group("NTLM authentication")
 	ntlm.add_argument("-u", "--username", help="The username")
-	ntlm.add_argument("-p", "--password", help="The password or the corresponding NTLM hash")
+	ntlm.add_argument("-p", "--password", help="The password used for the authentication")
+	ntlm.add_argument("-H", "--ntlm", help="The NTLM hash used for authentication, ex: aad3b435b51404eeaad3b435b51404ee:a2d4623d306be8e06dbc4e2e8b78353a")
 
 	kerberos = ldap.add_argument_group("Kerberos authentication")
 	kerberos.add_argument("-k", "--kerberos", action="store_true", help="For Kerberos authentication, ticket file should be pointed by $KRB5NAME env variable")
@@ -617,13 +618,16 @@ def main():
 			if args.kerberos:
 				method = "Kerberos"
 			elif args.username:
-				method = "NTLM"
+				if args.password:
+					method = "SIMPLE"
+				else:
+					method = "NTLM"
 			elif args.anonymous:
 				method = "anonymous"
 			else:
 				error("Lack of authentication options: either Kerberos, Username with Password (can be a NTLM hash) or Anonymous.")
-				
-			query_engine = LdapActiveDirectoryView(args.ldapserver, args.domain, args.base, args.username, args.password, method)
+
+			query_engine = LdapActiveDirectoryView(args.ldapserver, args.domain, args.base, args.username, args.password, args.ntlm, method)
 
 			
 		except LdapActiveDirectoryView.ActiveDirectoryLdapException as e:

--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -192,9 +192,11 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
 				authentication=NTLM, check_names=True
 			)
 		elif method == "SIMPLE":
+			if "." in domain:
+				domain = domain.split(".")[0]
 			self.ldap = Connection(
 				server,
-				user=f"{username}",
+				user=f"{domain}\\{username}",
 				password=password,
 				authentication=SIMPLE, check_names=True
 			)


### PR DESCRIPTION
When using ldeep I face a situation when NTLM authentication wasn't working. It is possible to perform a simple bind to make it work. This PR add an option to authenticate with password or NTLM hash and use associated authentication method (simple vs NTLM).
Also the help explain how to use NTLM hashes:
```
NTLM authentication:
  -u USERNAME, --username USERNAME
                        The username
  -p PASSWORD, --password PASSWORD
                        The password used for the authentication
  -H NTLM, --ntlm NTLM  The NTLM hash used for authentication, ex: aad3b435b51404eeaad3b435b51404ee:a2d4623d306be8e06dbc4e2e8b78353a
```