### PR TITLE
Changing install instructions from pypi to git url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ INSTALL
 
 ``ldeep`` is Python3 only.::
 
-	pip3 install ldeep
+	pip3 install git+https://github.com/franc-pentest/ldeep
 
 =====
 USAGE


### PR DESCRIPTION
As a temporary workaround to get the latest version of ldeep 😉 