### PR TITLE
New create_user feature, sped up ldap cache queries and bug fixes

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -1102,7 +1102,7 @@ class Ldeep(Command):
             return
 
         if self.engine.create_computer(computer, password):
-            info(f"Computer {computer} sucessfully created wit password {password}")
+            info(f"Computer {computer} sucessfully created with password {password}")
         else:
             if self.engine.ldap.result['result'] == coreResults.RESULT_UNWILLING_TO_PERFORM:
                 error_code = int(self.engine.ldap.result['message'].split(':')[0].strip(), 16)
@@ -1114,6 +1114,46 @@ class Ldeep(Command):
                 print(f"User {self.engine.username} doesn't have right to create a machine account!")
             elif self.engine.ldap.result['result'] == list(coreResults.RESULT_CODES.keys())[36]:
                 print(f"Computer {computer} already exists")
+            else:
+                error_message = self.engine.ldap.result['message']
+                print(f"ERROR: {error_message}")
+
+    def action_create_user(self, kwargs):
+        """
+        Create a user account
+
+        Arguments:
+            #user_name:string
+                Name of user to add.
+            #user_pass:string
+                Password set to user account
+        """
+        user = kwargs["user_name"]
+        password = kwargs["user_pass"]
+
+        try:
+            self.engine.ldap.start_tls()
+        except Exception as e:
+            print(f"Can't create user, TLS needed: {e}")
+            return
+
+        if self.engine.create_user(user, password):
+            info(f"User {user} sucessfully created with password {password}")
+        else:
+            if self.engine.ldap.result['result'] == coreResults.RESULT_UNWILLING_TO_PERFORM:
+                error_code = int(self.engine.ldap.result['message'].split(':')[0].strip(), 16)
+                print(f"ERROR: error_code = {error_code}")
+                if error_code == 0x216D:
+                    print(f"Machine quota exceeded with account {self.engine.username}")
+                else:
+                    print(str(self.engine.ldap.result))
+            elif self.engine.ldap.result['result'] == coreResults.RESULT_INSUFFICIENT_ACCESS_RIGHTS:
+                print(f"User {self.engine.username} doesn't have right to create a user account!")
+            elif self.engine.ldap.result['result'] == list(coreResults.RESULT_CODES.keys())[36]:
+                print(f"User {user} already exists")
+            else:
+                error_message = self.engine.ldap.result['message']
+                print(f"ERROR: {error_message}")
 
 
 def main():

--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -683,7 +683,6 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
         spns = [
             f"HOST/{computer}",
             f"HOST/{computer}.{self.domain}",
-            f"HOST/{computer}.{self.domain}",
             f"RestrictedKrbHost/{computer}",
             f"RestrictedKrbHost/{computer}.{self.domain}",
         ]

--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -699,3 +699,32 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
         except Exception as e:
             raise self.ActiveDirectoryLdapException(e)
         return result
+    def create_user(self, user, password):
+        """
+        Create a user account on the domain.
+
+        @user: the name of the create user.
+        @password: the password of the user to create.
+
+        @return the result code on the add action
+        """
+        user_dn = f'CN={user},CN=Users,{self.base_dn}'
+
+        ucd = {
+            'objectCategory': 'CN=Person,CN=Schema,CN=Configuration,%s' % self.base_dn,
+            'distinguishedName': user_dn,
+            'cn': user,
+            'sn': user,
+            'givenName': user,
+            'displayName': user,
+            'name': user,
+            'userAccountControl': 0x200, # NORMAL_ACCOUNT (decimal value: 512)
+            'accountExpires': 0,
+            'sAMAccountName': user,
+            'unicodePwd': ('"%s"' % password).encode('utf-16-le')
+        }
+        try:
+            result = self.ldap.add(user_dn, ["top", "person", "organizationalPerson", "user"], ucd)
+        except Exception as e:
+            raise self.ActiveDirectoryLdapException(e)
+        return result


### PR DESCRIPTION
This PR:
- adds the create_user() command
- speeds up ldap cache queries by only parsing files once in the query() function
- fixes some bugs and typos