### PR TITLE
Fix crash when trying to decode bad unicode

### DIFF
--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -100,7 +100,7 @@ def format_dnsrecord(raw_value):
                 target = inet_ntoa(data)
             else:
                 # how, ugly
-                data = data.decode('unicode-escape')
+                data = data.decode('unicode-escape', errors='replace')
                 target = ''.join([c for c in data if ord(c) > 31 or ord(c) == 9])
             return "%s %s" % (recordname, target)
 


### PR DESCRIPTION
Some records may contain characters that could not be decoded from unicode.
Using the `errors='replace'` allows the program to finish and return result while still showing that there are some weird records.