### PR TITLE
fix missing VERSION file issue for pdm build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ classifiers = [
   "Topic :: Security",
 ]
 
+[tool.pdm.build]
+includes = [
+  "ldeep/**",
+  "VERSION",
+]
+
 [tool.pdm.version]
 source = "call"
 getter = "ldeep:get_version"


### PR DESCRIPTION
I have run the pdm build in my local and confirm the VERSION file got added properly

fixes #77 

relates to https://github.com/Homebrew/homebrew-core/pull/173643