### PR TITLE
Allow recursive group enumeration for the primary group as well

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -1238,7 +1238,13 @@ class Ldeep(Command):
                 pid = result["primaryGroupID"]
                 results = list(self.engine.query(self.engine.PRIMARY_GROUP_ID(pid)))
                 if results:
-                    print(results[0]["dn"])
+                    dn = results[0]["dn"]
+                    print(dn)
+                    if recursive:
+                        already_printed.add(dn)
+                        s = lookup_groups(dn, 4, already_printed)
+                        already_printed.union(s)
+
         if len(list(results)) == 0:
             error("User {account} does not exists".format(account=account))
 


### PR DESCRIPTION
If the primary group of the target object is a member of an interesting group, the recursive query to find all groups for said object will not return the interesting group.
```
$ ldeep ldap -s ldap://192.168.99.11 -d domain.local -u user -p passwd memberships -r myuser
CN=Domain Users,CN=Users,DC=ff,DC=local
```
VS
```
$ ldeep ldap -s ldap://192.168.99.11 -d domain.local -u user -p passwd memberships -r myuser
CN=Domain Users,CN=Users,DC=ff,DC=local
    CN=test,CN=Users,DC=ff,DC=local
    CN=Users,CN=Builtin,DC=ff,DC=local
```