### PR TITLE
PSO Enum as low priv user

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -586,6 +586,40 @@ class Ldeep(Command):
                     )
                 print("{field}: {val}".format(field=field, val=val))
 
+        # enum principals affected by PSO if unpriv
+        print("Unprivileged enumeration:")
+        print("principal:pso_name")
+        # users
+        attributes = ["objectClass", "cn", "sAMAccountName", "msDS-PSOApplied"]
+        entries = self.engine.query(self.engine.USER_ALL_FILTER(), attributes)
+        for entry in entries:
+            psos = entry.get("msDS-PSOApplied")
+            if psos:
+                for pso in psos:
+                    pso = next(
+                        map(
+                            lambda x: x.replace("CN=", ""),
+                            filter(lambda x: x.startswith("CN="), pso.split(",")),
+                        )
+                    )
+                    name = entry.get("sAMAccountName")
+                    print(f"{name}:{pso}")
+
+        # groups
+        entries = self.engine.query(self.engine.GROUPS_FILTER(), attributes)
+        for entry in entries:
+            psos = entry.get("msDS-PSOApplied")
+            if psos:
+                for pso in psos:
+                    pso = next(
+                        map(
+                            lambda x: x.replace("CN=", ""),
+                            filter(lambda x: x.startswith("CN="), pso.split(",")),
+                        )
+                    )
+                    name = entry.get("sAMAccountName")
+                    print(f"{name}:{pso}")
+
     def list_trusts(self, kwargs):
         """
         List the domain's trust relationships.

--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -587,8 +587,7 @@ class Ldeep(Command):
                 print("{field}: {val}".format(field=field, val=val))
 
         # enum principals affected by PSO if unpriv
-        print("Unprivileged enumeration:")
-        print("principal:pso_name")
+        results = []
         # users
         attributes = ["objectClass", "cn", "sAMAccountName", "msDS-PSOApplied"]
         entries = self.engine.query(self.engine.USER_ALL_FILTER(), attributes)
@@ -603,7 +602,7 @@ class Ldeep(Command):
                         )
                     )
                     name = entry.get("sAMAccountName")
-                    print(f"{name}:{pso}")
+                    results.append(f"{name}:{pso}")
 
         # groups
         entries = self.engine.query(self.engine.GROUPS_FILTER(), attributes)
@@ -618,7 +617,12 @@ class Ldeep(Command):
                         )
                     )
                     name = entry.get("sAMAccountName")
-                    print(f"{name}:{pso}")
+                    results.append(f"{name}:{pso}")
+
+        if results:
+            print("Unprivileged enumeration:")
+            print("principal:pso_name")
+            print(*results, sep="\n")
 
     def list_trusts(self, kwargs):
         """

--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -656,16 +656,19 @@ class Ldeep(Command):
         else:
             attributes = ALL
 
-        self.display(
-            self.engine.query(
-                self.engine.ZONES_FILTER(),
-                attributes,
-                base=",".join(
-                    ["CN=MicrosoftDNS,DC=DomainDNSZones", self.engine.base_dn]
+        try:
+            self.display(
+                self.engine.query(
+                    self.engine.ZONES_FILTER(),
+                    attributes,
+                    base=",".join(
+                        ["CN=MicrosoftDNS,DC=DomainDNSZones", self.engine.base_dn]
+                    ),
                 ),
-            ),
-            verbose,
-        )
+                verbose,
+            )
+        except:
+            error(f"Can't list zones", close_array=verbose)
 
     def list_pkis(self, kwargs):
         """


### PR DESCRIPTION
Even if a low priv user cannot have details on Password Settings Object, it is still possible to enumerate which principals (Users and Groups by default) are subject to this setting.

```
$ ldeep ldap -u bob -p password -s 192.168.57.5 -d corp pso
Unprivileged enumeration:
principal:pso_name
user:PSO2
user:DA-PSO
Domain Admins:DA-PSO
```