### PR TITLE
chore: update requires-python to support py3.13 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "termcolor >= 2.3.0, < 3",
     "tqdm >= 4.26.0, < 5",
 ]
-requires-python = ">=3.8.1,<3.13"
+requires-python = ">=3.8.1,<3.14"
 readme = "README.rst"
 license = {text = "MIT"}
 keywords = [


### PR DESCRIPTION
update requires-python to support py3.13 build

relates to https://github.com/Homebrew/homebrew-core/pull/194268