### PR TITLE
Recover missing DNS records

### DIFF
--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -107,6 +107,12 @@ class Ldeep(Command):
                 elif "dnsZone" in record["objectClass"]:
                     print(record["dc"])
                 elif (
+                    not record["objectClass"]
+                    and not record.get('dnsRecord', None) is None
+                ):
+                    if record['dn'][0:2] == "DC":
+                        print(f"{record['dn'][3:].split(',')[0]}")
+                elif (
                     "domainDNS" in record["objectClass"]
                     and "fSMORoleOwner" in record.keys()
                 ):

--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -209,7 +209,7 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
     )
     GROUPS_FILTER = lambda _: "(objectClass=group)"
     ZONES_FILTER = lambda _: "(&(objectClass=dnsZone)(!(dc=RootDNSServers)))"
-    DNS_FILTER = lambda _: "(objectClass=dnsNode)"
+    DNS_FILTER = lambda _: "(objectClass=*)"
     SITES_FILTER = lambda _: "(objectClass=site)"
     SUBNET_FILTER = lambda _, s: f"(SiteObject={s})"
     PKI_FILTER = lambda _: "(objectClass=pKIEnrollmentService)"


### PR DESCRIPTION
Missing DNS records by previously filtering on objectClass DnsNode. When no particular rights on the record, objectClass is empty but can recover the distinguishedName.