### PR TITLE
feat: add BloodHound export support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Help is self-explanatory. Let's check it out::
   Mode:
     Available modes
 
-    {ldap,cache}          Backend engine to retrieve data
+    {ldap,cache,bloodhound,protections}          Backend engine to retrieve data
 
 
 `ldeep` can either run against an Active Directory LDAP server or locally on saved files::
@@ -181,7 +181,22 @@ Help is self-explanatory. Let's check it out::
   Administrator
   [...]
 
-These two modes have different options:
+An existing ldeep cache can be converted directly with the dedicated
+``bloodhound`` mode::
+
+  $ ldeep bloodhound -d backup -p winlab -o /tmp/bh_result
+  [+] Retrieving gpo BloodHound output
+  [+] Retrieving conf BloodHound source data
+  [+] Retrieving ou BloodHound output
+  [+] Retrieving machines BloodHound output
+  [+] Retrieving domain_policy BloodHound output
+  [+] Retrieving groups BloodHound output
+  [+] Retrieving pkis BloodHound output
+  [+] Retrieving users BloodHound output
+
+If some files information are not present (eg, the cache only contains users info), ldeep will still generate all bloodhound files only with empty data where it does not have sufficient info
+
+These three modes have different options:
 
 ----
 LDAP
@@ -343,7 +358,22 @@ CACHE
         silo                Get information about a specific `silo`.
         zone                Return the records of a DNS zone.
 
+-----
+BLODHOUND
+-----
 
+::
+
+  $ ldeep bloodhound -h
+  usage: ldeep bloodhound [-h] [-d DIR] -p PREFIX -o OUTPUT
+
+  Convert an existing ldeep cache to BloodHound JSON
+
+  options:
+    -h, --help           show this help message and exit
+    -d, --dir DIR        Directory containing the ldeep cache
+    -p, --prefix PREFIX  Prefix of the ldeep cache files
+    -o, --output OUTPUT  Directory where bh_*.json files will be written
 
 
 ==============

--- a/ldeep/__main__.py
+++ b/ldeep/__main__.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 from argparse import ArgumentParser
-from base64 import b64decode, b64encode
+from base64 import b64encode
 from datetime import date, datetime, timedelta
 from itertools import chain
 from json import dump as json_dump
 from math import fabs
-from re import compile as re_compile, IGNORECASE
+from re import IGNORECASE
+from re import compile as re_compile
 from time import sleep
 from uuid import UUID
 
@@ -22,6 +24,15 @@ from pyasn1.error import PyAsn1UnicodeDecodeError
 from ldeep._version import __version__
 from ldeep.utils import Logger, error, get_key_for_value, info
 from ldeep.utils import resolve as utils_resolve
+from ldeep.utils.bloodhound import (
+    BLOODHOUND_NODE_TYPES,
+    configuration_object_type,
+    convert_certtemplates,
+    convert_configuration,
+)
+from ldeep.utils.bloodhound import (
+    convert as convert_bloodhound,
+)
 from ldeep.utils.protections import checkProtections
 from ldeep.utils.sddl import parse_ntSecurityDescriptor
 from ldeep.views.activedirectory import (
@@ -42,11 +53,35 @@ from ldeep.views.ldap_activedirectory import LdapActiveDirectoryView
 from ldeep.views.structures import MSDS_MANAGEDPASSWORD_BLOB
 
 
+def _record_identity(record):
+    for field in ("objectGUID", "objectSid", "distinguishedName", "dn"):
+        value = record.get(field)
+        if value:
+            if isinstance(value, (list, tuple)):
+                value = tuple(value)
+            return field, str(value).casefold()
+    return None
+
+
+def _deduplicate_records(records):
+    result = []
+    seen = set()
+    for record in records:
+        identity = _record_identity(record) if isinstance(record, dict) else None
+        if identity is None or identity not in seen:
+            result.append(record)
+            if identity is not None:
+                seen.add(identity)
+    return result
+
+
 class Ldeep(Command):
     def __init__(self, query_engine, format="json"):
         self.engine = query_engine
+        self.bloodhound = format == "bloodhound"
+        self.bloodhound_type_hint = None
         self.dns_record_regexp = None
-        if format == "json":
+        if format in ("json", "bloodhound"):
             self.__display = self.__display_json
 
     def extract_record_from_dn(self, dn: str) -> str:
@@ -70,7 +105,10 @@ class Ldeep(Command):
                 return b64encode(o).decode("ascii")
 
         if verbose:
-            self.__display(records, default)
+            if self.bloodhound:
+                self.__display_bloodhound(records, default)
+            else:
+                self.__display(records, default)
         else:
             k = 0
             for record in records:
@@ -297,6 +335,283 @@ class Ldeep(Command):
         sys.stdout.write("]\n")
         sys.stdout.flush()
 
+    def __display_bloodhound(self, records, default):
+        records = list(records)
+        if self.bloodhound_type_hint == "users":
+            records.extend(getattr(self, "bloodhound_gmsa_records", []))
+            records = _deduplicate_records(records)
+        if self.bloodhound_type_hint in {"users", "groups", "computers"}:
+            principals = getattr(self, "bloodhound_principal_records", [])
+            known_sids = {
+                record.get("objectSid")
+                for record in principals
+                if isinstance(record, dict)
+            }
+            principals.extend(
+                record
+                for record in records
+                if isinstance(record, dict)
+                and record.get("objectSid") not in known_sids
+            )
+        principal_cache = {}
+
+        def available_cache_files(*names):
+            if not isinstance(self.engine, CacheActiveDirectoryView):
+                return list(names)
+            expanded_names = []
+            for name in names:
+                if name == "users_all":
+                    expanded_names.extend(self.engine.user_cache_files())
+                elif name == "machines":
+                    expanded_names.extend(self.engine.computer_cache_files())
+                else:
+                    expanded_names.append(name)
+            return [
+                name
+                for name in expanded_names
+                if any(
+                    os.path.exists(
+                        os.path.join(
+                            self.engine.path,
+                            f"{self.engine.prefix}_{name}.{extension}",
+                        )
+                    )
+                    for extension in ("json", "lst")
+                )
+            ]
+
+        def resolve_member(distinguished_name):
+            try:
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    files = available_cache_files(
+                        "users_all",
+                        "gmsa",
+                        "groups",
+                        "machines",
+                        "fsp",
+                        "shadow_principals",
+                    )
+                    if not files:
+                        return None
+                    member_filter = {
+                        "fmt": "json",
+                        "files": files,
+                        "filter": lambda record: (
+                            record.get("distinguishedName") == distinguished_name
+                        ),
+                    }
+                else:
+                    member_filter = self.engine.DISTINGUISHED_NAME(distinguished_name)
+                results = self.engine.query(member_filter, ["objectSid", "objectClass"])
+                return next(iter(results), None)
+            except Exception:
+                return None
+
+        def resolve_principal(sid):
+            if sid in principal_cache:
+                return principal_cache[sid]
+            try:
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    files = available_cache_files(
+                        "users_all",
+                        "gmsa",
+                        "groups",
+                        "machines",
+                        "fsp",
+                        "shadow_principals",
+                    )
+                    if not files:
+                        principal_cache[sid] = None
+                        return None
+                    principal_filter = {
+                        "fmt": "json",
+                        "files": files,
+                        "filter": lambda record: (
+                            record.get("objectSid") == sid
+                            or sid
+                            in (
+                                record.get("msDS-ShadowPrincipalSid")
+                                if isinstance(
+                                    record.get("msDS-ShadowPrincipalSid"), list
+                                )
+                                else [record.get("msDS-ShadowPrincipalSid")]
+                            )
+                        ),
+                    }
+                else:
+                    principal_filter = f"(objectSid={sid})"
+                principal_cache[sid] = next(
+                    iter(
+                        self.engine.query(
+                            principal_filter, ["objectSid", "objectClass"]
+                        )
+                    ),
+                    None,
+                )
+            except Exception:
+                principal_cache[sid] = None
+            return principal_cache[sid]
+
+        def resolve_host(hostname):
+            try:
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    files = available_cache_files("machines")
+                    if not files:
+                        return None
+                    host_filter = {
+                        "fmt": "json",
+                        "files": files,
+                        "filter": lambda record: (
+                            str(record.get("dNSHostName", "")).lower()
+                            == str(hostname).lower()
+                        ),
+                    }
+                else:
+                    host_filter = f"(dNSHostName={hostname})"
+                return next(iter(self.engine.query(host_filter, ["objectSid"])), None)
+            except Exception:
+                return None
+
+        domain_sid = ""
+        try:
+            has_domain_policy = True
+            if isinstance(self.engine, CacheActiveDirectoryView):
+                has_domain_policy = any(
+                    os.path.exists(
+                        os.path.join(
+                            self.engine.path,
+                            f"{self.engine.prefix}_domain_policy.{extension}",
+                        )
+                    )
+                    for extension in ("json", "lst")
+                )
+            if has_domain_policy:
+                domain_filter = self.engine.DOMAIN_INFO_FILTER()
+                if isinstance(domain_filter, dict):
+                    domain_filter = dict(domain_filter)
+                    domain_filter.pop("fmt", None)
+                domain_records = self.engine.query(domain_filter, ["objectSid"])
+                domain_record = next(iter(domain_records), None)
+                if isinstance(domain_record, dict):
+                    domain_sid = domain_record.get("objectSid", "")
+        except Exception:
+            pass
+        self.bloodhound_domain_sid = domain_sid
+        self.bloodhound_last_records = records
+
+        trust_records = None
+        object_type_guids = None
+        if isinstance(self.engine, LdapActiveDirectoryView):
+            try:
+                self.engine.create_objecttype_guid_map()
+                object_type_guids = self.engine.objecttype_guid_map
+            except Exception:
+                # Schema enumeration is an enhancement for LDAP mode.  The
+                # static GUIDs still cover the standard BloodHound rights.
+                object_type_guids = None
+        domain_controllers = None
+        if self.bloodhound_type_hint == "groups":
+            try:
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    files = available_cache_files("machines")
+                    if files:
+                        dc_filter = {
+                            "fmt": "json",
+                            "files": files,
+                            "filter": lambda record: (
+                                record.get("primaryGroupID") == 516
+                            ),
+                        }
+                    else:
+                        domain_controllers = []
+                else:
+                    dc_filter = self.engine.DC_FILTER()
+                if domain_controllers is not None:
+                    domain_controllers = list(
+                        self.engine.query(dc_filter, ["objectSid", "objectClass"])
+                    )
+            except Exception:
+                domain_controllers = None
+        if any(
+            isinstance(record, dict)
+            and any(
+                str(object_class).lower() in {"domain", "domaindns"}
+                for object_class in (record.get("objectClass") or [])
+            )
+            for record in records
+        ):
+            try:
+                trust_filter = self.engine.TRUSTS_INFO_FILTER()
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    files = available_cache_files("trusts")
+                    if files:
+                        trust_filter = dict(trust_filter)
+                        trust_filter["files"] = files
+                        trust_records = self.engine.query(trust_filter)
+                    else:
+                        trust_records = []
+                else:
+                    trust_records = self.engine.query(trust_filter)
+            except Exception:
+                trust_records = None
+
+        computer_records = getattr(self, "bloodhound_computer_records", [])
+        if (
+            not computer_records
+            and isinstance(self.engine, CacheActiveDirectoryView)
+            and self.bloodhound_type_hint in {"domains", "ous"}
+        ):
+            # Reuse the existing machines cache as conversion context.  This
+            # does not add a collection method or query a new data source.
+            try:
+                if available_cache_files("machines"):
+                    computer_records = list(
+                        self.engine.query(
+                            self.engine.COMPUTERS_FILTER("*"),
+                            self.engine.all_attributes(),
+                        )
+                    )
+                else:
+                    computer_records = []
+            except Exception:
+                computer_records = []
+
+        document = convert_bloodhound(
+            records,
+            resolve_member=resolve_member,
+            resolve_principal=resolve_principal,
+            resolve_host=resolve_host,
+            domain_sid=domain_sid,
+            trusts=trust_records,
+            include_well_known=True,
+            object_type_hint=self.bloodhound_type_hint,
+            object_type_guids=object_type_guids,
+            domain_controllers=domain_controllers,
+            certtemplate_records=[
+                record
+                for record in getattr(self, "bloodhound_configuration_records", [])
+                if isinstance(record, dict)
+                and configuration_object_type(record) == "certtemplates"
+            ],
+            gpo_records=getattr(self, "bloodhound_gpo_records", []),
+            configuration_records=getattr(self, "bloodhound_configuration_records", []),
+            containment_records=(
+                list(getattr(self, "bloodhound_ou_records", []))
+                + list(getattr(self, "bloodhound_configuration_records", []))
+            ),
+            computer_records=computer_records,
+        )
+        json_dump(
+            document,
+            sys.stdout,
+            ensure_ascii=False,
+            default=default,
+            sort_keys=True,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
     # LISTERS #
 
     def list_server_info(self, kwargs):
@@ -325,6 +640,7 @@ class Ldeep(Command):
                 Results will contain full information
             @filter:string = ["all", "spn", "enabled", "disabled", "locked", "nopasswordexpire", "passwordexpired", "passwordnotrequired", "nokrbpreauth", "reversible"]
         """
+        self.bloodhound_type_hint = "users"
         verbose = kwargs.get("verbose", False)
         filter_ = kwargs.get("filter", "all")
 
@@ -405,7 +721,7 @@ class Ldeep(Command):
                 attributes,
             )
         else:
-            return None
+            return
 
         self.display(results, verbose)
 
@@ -417,6 +733,7 @@ class Ldeep(Command):
             @verbose:bool
                 Results will contain full information
         """
+        self.bloodhound_type_hint = "groups"
         verbose = kwargs.get("verbose", False)
 
         if verbose:
@@ -440,6 +757,7 @@ class Ldeep(Command):
             #machine:string = '*'
                 Target machine
         """
+        self.bloodhound_type_hint = "computers"
         verbose = kwargs.get("verbose", False)
         machine = kwargs.get("machine", "*")
 
@@ -448,11 +766,14 @@ class Ldeep(Command):
         else:
             attributes = ["sAMAccountName", "objectClass"]
 
-        self.display(
-            self.engine.query(self.engine.COMPUTERS_FILTER(machine), attributes),
-            verbose,
-            specify_group=False,
+        records = list(
+            self.engine.query(self.engine.COMPUTERS_FILTER(machine), attributes)
         )
+        if self.bloodhound:
+            self.bloodhound_computer_records = records
+            if hasattr(self, "bloodhound_principal_records"):
+                self.bloodhound_principal_records.extend(records)
+        self.display(records, verbose, specify_group=False)
 
     def list_fsp(self, kwargs):
         """
@@ -491,9 +812,27 @@ class Ldeep(Command):
             @dc:bool
                 List only domain controllers
         """
+        self.bloodhound_type_hint = "computers"
         resolve = "resolve" in kwargs and kwargs["resolve"]
         dns = kwargs.get("dns", "")
         dc = kwargs.get("dc", False)
+
+        if self.bloodhound:
+            computer_filter = (
+                self.engine.DC_FILTER() if dc else self.engine.COMPUTERS_FILTER("*")
+            )
+            records = list(
+                self.engine.query(computer_filter, self.engine.all_attributes())
+            )
+            self.bloodhound_computer_records = records
+            if hasattr(self, "bloodhound_principal_records"):
+                self.bloodhound_principal_records.extend(records)
+            self.display(
+                records,
+                True,
+                specify_group=False,
+            )
+            return
 
         hostnames = []
         if not dc:
@@ -529,6 +868,7 @@ class Ldeep(Command):
             @target:string
                 Retrieve only the information regarding the specified target account
         """
+        self.bloodhound_type_hint = "computers"
         verbose = kwargs.get("verbose", False)
         target = kwargs.get("target", "*")
         hidden_attributes = ["msDS-ManagedPassword"]
@@ -621,6 +961,9 @@ class Ldeep(Command):
             entry["aes128-cts-hmac-sha1-96"] = f"{aes128_key.hex()}"
             entry["aes256-cts-hmac-sha1-96"] = f"{aes256_key.hex()}"
 
+        if kwargs.get("_bloodhound_collect_only"):
+            self.bloodhound_gmsa_records = entries
+            return
         if verbose:
             self.display(entries, verbose)
         else:
@@ -654,6 +997,7 @@ class Ldeep(Command):
             @verbose:bool
                 Results will contain full information
         """
+        self.bloodhound_type_hint = "domains"
         verbose = kwargs.get("verbose", False)
 
         if verbose:
@@ -675,9 +1019,15 @@ class Ldeep(Command):
                 "msDS-Behavior-Version",
             ]
 
-        self.display(
-            self.engine.query(self.engine.DOMAIN_INFO_FILTER(), attributes), verbose
-        )
+        domain_filter = self.engine.DOMAIN_INFO_FILTER()
+        if self.bloodhound and isinstance(domain_filter, dict):
+            # The cache normally forces domain_policy to its human-readable
+            # .lst representation. BloodHound requires the detailed JSON
+            # record instead.
+            domain_filter = dict(domain_filter)
+            domain_filter.pop("fmt", None)
+
+        self.display(self.engine.query(domain_filter, attributes), verbose)
 
     def list_ou(self, kwargs):
         """
@@ -689,6 +1039,7 @@ class Ldeep(Command):
             #ou:string = '*'
                 Target ou
         """
+        self.bloodhound_type_hint = "ous"
         verbose = kwargs.get("verbose", False)
         ou = kwargs.get("ou", "*")
 
@@ -697,7 +1048,9 @@ class Ldeep(Command):
         else:
             attributes = ["objectClass", "gPLink"]
 
-        ous = self.engine.query(self.engine.OU_FILTER(ou), attributes)
+        ous = list(self.engine.query(self.engine.OU_FILTER(ou), attributes))
+        if self.bloodhound:
+            self.bloodhound_ou_records = ous
         results = self.engine.query(
             self.engine.GPO_INFO_FILTER("*"), ["cn", "displayName"]
         )
@@ -717,6 +1070,7 @@ class Ldeep(Command):
             #gpo:string = '*'
                 Target gpo
         """
+        self.bloodhound_type_hint = "gpos"
         verbose = kwargs.get("verbose", False)
         gpo = kwargs.get("gpo", "*")
 
@@ -725,9 +1079,10 @@ class Ldeep(Command):
         else:
             attributes = ["objectClass", "cn", "displayName"]
 
-        self.display(
-            self.engine.query(self.engine.GPO_INFO_FILTER(gpo), attributes), verbose
-        )
+        records = list(self.engine.query(self.engine.GPO_INFO_FILTER(gpo), attributes))
+        if self.bloodhound:
+            self.bloodhound_gpo_records = records
+        self.display(records, verbose)
 
     def list_pso(self, _):
         """
@@ -769,14 +1124,12 @@ class Ldeep(Command):
                 else:
                     val = policy[field]
 
-                if field in FILETIME_TIMESTAMP_FIELDS.keys():
+                if field in FILETIME_TIMESTAMP_FIELDS:
                     val = int(
                         (fabs(float(val)) / 10**7) / FILETIME_TIMESTAMP_FIELDS[field][0]
                     )
-                    val = "{val} {typ}".format(
-                        val=val, typ=FILETIME_TIMESTAMP_FIELDS[field][1]
-                    )
-                print("{field}: {val}".format(field=field, val=val))
+                    val = f"{val} {FILETIME_TIMESTAMP_FIELDS[field][1]}"
+                print(f"{field}: {val}")
 
         # enum principals affected by PSO if unpriv
         results = []
@@ -872,8 +1225,8 @@ class Ldeep(Command):
             for field in FIELDS_TO_PRINT:
                 if field in result:
                     val = result[field]
-                    print("{field}: {val}".format(field=field, val=val))
-            print("")
+                    print(f"{field}: {val}")
+            print()
 
     def list_zones(self, kwargs):
         """
@@ -955,7 +1308,7 @@ class Ldeep(Command):
                     )
                 )
 
-            except LdapActiveDirectoryView.ActiveDirectoryLdapException as e:
+            except LdapActiveDirectoryView.ActiveDirectoryLdapException:
                 error(f"Can't list {name.lower()} records", close_array=verbose)
             else:
                 filteredResults = []
@@ -985,6 +1338,7 @@ class Ldeep(Command):
             @verbose:bool
                 Results will contain full information
         """
+        self.bloodhound_type_hint = "enterprisecas"
         verbose = kwargs.get("verbose", False)
 
         if verbose:
@@ -1157,15 +1511,15 @@ class Ldeep(Command):
                     )
                     servers_list = [d["cn"] for d in servers]
 
-                    output = "Site: {}".format(site_name)
-                    output += " | Subnet: {}".format(subnet_name) if subnet_name else ""
+                    output = f"Site: {site_name}"
+                    output += f" | Subnet: {subnet_name}" if subnet_name else ""
                     output += (
-                        " | Site description: {}".format(site_description)
+                        f" | Site description: {site_description}"
                         if site_description
                         else ""
                     )
                     output += (
-                        " | Subnet description: {}".format(subnet_description)
+                        f" | Subnet description: {subnet_description}"
                         if subnet_description
                         else ""
                     )
@@ -1180,14 +1534,24 @@ class Ldeep(Command):
         """
         Dump the configuration partition of the Active Directory.
         """
-        self.display(
+        configuration_base = None
+        if not isinstance(self.engine, CacheActiveDirectoryView):
+            configuration_base = ",".join(["CN=Configuration", self.engine.base_dn])
+        records = list(
             self.engine.query(
                 self.engine.ALL_FILTER(),
                 ALL,
-                base=",".join(["CN=Configuration", self.engine.base_dn]),
-            ),
-            True,
+                base=configuration_base,
+            )
         )
+        if self.bloodhound:
+            # ``cache all`` already includes the conf collection.  Keep it
+            # in memory so the BloodHound exporter can split it into the
+            # dedicated Container/ADCS node files without querying anything
+            # else.
+            self.bloodhound_configuration_records = records
+            return
+        self.display(records, True)
 
     def list_schema(self, kwargs):
         """
@@ -1323,10 +1687,8 @@ class Ldeep(Command):
             else:
                 for entry in entries:
                     print(
-                        (
-                            f"Members of the shadow principal {entry['name']} "
-                            f"(shadow principal SID: {entry['msDS-ShadowPrincipalSid']}):"
-                        )
+                        f"Members of the shadow principal {entry['name']} "
+                        f"(shadow principal SID: {entry['msDS-ShadowPrincipalSid']}):"
                     )
                     for member in entry.get("member", []):
                         print(f"{member:>{len(member) + 4}}")
@@ -1424,7 +1786,7 @@ class Ldeep(Command):
                     attributes,
                 )
             else:
-                return None
+                return
 
             # Force the actual LDAP request to be done there, to catch potential LDAPAttributeError errors related
             # to an old domain functional level. We don't want to miss the other delegation types because of RBCD
@@ -1783,7 +2145,7 @@ class Ldeep(Command):
         groups_from_primary_group = []
         # For some reason, when we request an attribute which is not set on an object,
         # ldap3 returns an empty list as the value of this attribute
-        if "primaryGroupID" in target_obj and target_obj["primaryGroupID"]:
+        if target_obj.get("primaryGroupID"):
             try:
                 pgid = target_obj["primaryGroupID"]
                 pg_res = list(self.engine.query(self.engine.PRIMARY_GROUP_ID(pgid)))
@@ -1796,7 +2158,7 @@ class Ldeep(Command):
 
         # Handle direct 'memberOf' groups
         groups_from_memberof = []
-        if "memberOf" in target_obj and target_obj["memberOf"]:
+        if target_obj.get("memberOf"):
             groups = target_obj["memberOf"]
             for group_dn in groups:
                 groups_from_memberof.append(process_group(group_dn, 0))
@@ -1935,7 +2297,7 @@ class Ldeep(Command):
                     parse_readers(entry)
             else:
                 self.display(entries, verbose)
-        except Exception as e:
+        except Exception:
             # Silently fail if v1 attributes don't exist
             print("LAPSv1 not detected")
         try:
@@ -1962,7 +2324,7 @@ class Ldeep(Command):
                                 f"{c['dNSHostName']}:::{b64encode(c['msLAPS-EncryptedPassword'])}"
                             )
                         parse_readers(c)
-        except Exception as e:
+        except Exception:
             # Silently fail if v2 attributes don't exist
             print("LAPSv2 not detected")
 
@@ -2024,7 +2386,7 @@ class Ldeep(Command):
                 "msDS-UserAuthNPolicy",
             ]
         else:
-            return None
+            return
 
         try:
             results = list(
@@ -2072,7 +2434,9 @@ class Ldeep(Command):
         filter_ = kwargs["filter"]
 
         try:
-            if attr and attr != "ALL":
+            if self.bloodhound:
+                results = self.engine.query(filter_)
+            elif attr and attr != "ALL":
                 results = self.engine.query(filter_, attr.split(","))
             else:
                 results = self.engine.query(filter_)
@@ -2094,32 +2458,173 @@ class Ldeep(Command):
                 File prefix for the files that will be created during the execution
         """
         output = kwargs["output"]
+
+        if self.bloodhound:
+            if kwargs.get("output_dir"):
+                os.makedirs(output, exist_ok=True)
+                output = os.path.join(output, "bh")
+
+            def write_document(object_type, document):
+                with open(
+                    f"{output}_{object_type}.json", "w", encoding="utf-8"
+                ) as document_file:
+                    json_dump(
+                        document,
+                        document_file,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        indent=2,
+                    )
+
+            self.bloodhound_configuration_records = []
+            self.bloodhound_gmsa_records = []
+            self.bloodhound_ou_records = []
+            self.bloodhound_computer_records = []
+            self.bloodhound_principal_records = []
+            for object_type in BLOODHOUND_NODE_TYPES:
+                write_document(
+                    object_type,
+                    convert_bloodhound([], object_type_hint=object_type),
+                )
+            # BloodHound accepts one node type per JSON file.  Keep the
+            # useful AD object collections from ldeep's aggregate command and
+            # emit them directly as importable BloodHound files.
+            bloodhound_commands = {
+                "domain_policy": "domains",
+                "gpo": "gpos",
+                "groups": "groups",
+                "machines": "computers",
+                "ou": "ous",
+                "pkis": "enterprisecas",
+                "users": "users",
+            }
+            cache_files = {
+                "domain_policy": "domain_policy",
+                "gpo": "gpo",
+                "groups": "groups",
+                "machines": "machines",
+                "ou": "ou",
+                "pkis": "pkis",
+                "users": "users_all",
+            }
+            commands = list(self.get_commands(prefix="list_"))
+            command_order = {
+                "gpo": 0,
+                "conf": 1,
+                "ou": 2,
+                "machines": 3,
+                "domain_policy": 4,
+                "groups": 5,
+                "pkis": 6,
+                "gmsa": 7,
+                "users": 8,
+            }
+            commands.sort(key=lambda item: command_order.get(item[0], 99))
+            for command, method in commands:
+                if command == "gmsa":
+                    if isinstance(
+                        self.engine, CacheActiveDirectoryView
+                    ) and not self.engine.has_cache_file("gmsa"):
+                        continue
+                    kwargs["verbose"] = True
+                    kwargs["_bloodhound_collect_only"] = True
+                    getattr(self, method)(kwargs)
+                    kwargs.pop("_bloodhound_collect_only", None)
+                    continue
+                if command == "conf":
+                    if isinstance(self.engine, CacheActiveDirectoryView) and not any(
+                        os.path.exists(
+                            os.path.join(
+                                self.engine.path,
+                                f"{self.engine.prefix}_conf.{extension}",
+                            )
+                        )
+                        for extension in ("json", "lst")
+                    ):
+                        continue
+                    info("Retrieving conf BloodHound source data")
+                    kwargs["verbose"] = True
+                    getattr(self, method)(kwargs)
+                    continue
+                object_type = bloodhound_commands.get(command)
+                if not object_type:
+                    continue
+                if isinstance(self.engine, CacheActiveDirectoryView):
+                    if command == "users":
+                        if not self.engine.user_cache_files() and not (
+                            isinstance(self.engine, CacheActiveDirectoryView)
+                            and self.engine.has_cache_file("gmsa")
+                        ):
+                            continue
+                    elif command == "machines":
+                        if not self.engine.computer_cache_files():
+                            continue
+                    else:
+                        cache_file = cache_files[command]
+                        if not any(
+                            os.path.exists(
+                                os.path.join(
+                                    self.engine.path,
+                                    f"{self.engine.prefix}_{cache_file}.{extension}",
+                                )
+                            )
+                            for extension in ("json", "lst")
+                        ):
+                            continue
+                info(f"Retrieving {command} BloodHound output")
+                sys.stdout = Logger(
+                    f"{output}_{object_type}.json",
+                    quiet=True,
+                )
+                kwargs["verbose"] = True
+                getattr(self, method)(kwargs)
+                if object_type == "enterprisecas":
+                    self.bloodhound_enterpriseca_records = getattr(
+                        self, "bloodhound_last_records", []
+                    )
+                    certtemplates = convert_certtemplates(
+                        getattr(self, "bloodhound_last_records", []),
+                        domain_sid=getattr(self, "bloodhound_domain_sid", ""),
+                        configuration_records=getattr(
+                            self, "bloodhound_configuration_records", []
+                        ),
+                        principal_records=(
+                            list(getattr(self, "bloodhound_principal_records", []))
+                            + list(getattr(self, "bloodhound_computer_records", []))
+                        ),
+                    )
+                    write_document("certtemplates", certtemplates)
+            configuration_documents = convert_configuration(
+                getattr(self, "bloodhound_configuration_records", []),
+                domain_sid=getattr(self, "bloodhound_domain_sid", ""),
+                certificate_records=getattr(
+                    self, "bloodhound_enterpriseca_records", []
+                ),
+                principal_records=getattr(self, "bloodhound_principal_records", [])
+                + list(getattr(self, "bloodhound_computer_records", [])),
+            )
+            for object_type, document in configuration_documents.items():
+                write_document(object_type, document)
+            return
+
         kwargs["verbose"] = False
 
         for command, method in self.get_commands(prefix="list_"):
-            info("Retrieving {command} output".format(command=command))
+            info(f"Retrieving {command} output")
             if self.has_option(method, "filter"):
                 filter_ = self.retrieve_default_val_for_arg(method, "filter")
                 for f in filter_:
                     sys.stdout = Logger(
-                        "{output}_{command}_{filter}.lst".format(
-                            output=output, command=command, filter=f
-                        ),
+                        f"{output}_{command}_{f}.lst",
                         quiet=True,
                     )
                     kwargs["filter"] = f
                     getattr(self, method)(kwargs)
 
                     if self.has_option(method, "verbose"):
-                        info(
-                            "Retrieving {command} verbose output".format(
-                                command=command
-                            )
-                        )
+                        info(f"Retrieving {command} verbose output")
                         sys.stdout = Logger(
-                            "{output}_{command}_{filter}.json".format(
-                                output=output, command=command, filter=f
-                            ),
+                            f"{output}_{command}_{f}.json",
                             quiet=True,
                         )
                         kwargs["verbose"] = True
@@ -2128,17 +2633,15 @@ class Ldeep(Command):
                 kwargs["filter"] = None
             else:
                 sys.stdout = Logger(
-                    "{output}_{command}.lst".format(output=output, command=command),
+                    f"{output}_{command}.lst",
                     quiet=True,
                 )
                 getattr(self, method)(kwargs)
 
                 if self.has_option(method, "verbose"):
-                    info("Retrieving {command} verbose output".format(command=command))
+                    info(f"Retrieving {command} verbose output")
                     sys.stdout = Logger(
-                        "{output}_{command}.json".format(
-                            output=output, command=command
-                        ),
+                        f"{output}_{command}.json",
                         quiet=True,
                     )
                     kwargs["verbose"] = True
@@ -2199,13 +2702,9 @@ class Ldeep(Command):
         user = kwargs["user"]
 
         if self.engine.unlock(user):
-            info(
-                "User {username} unlocked (or was already unlocked)".format(
-                    username=user
-                )
-            )
+            info(f"User {user} unlocked (or was already unlocked)")
         else:
-            error("Unable to unlock {username}, check privileges".format(username=user))
+            error(f"Unable to unlock {user}, check privileges")
 
     def action_modify_password(self, kwargs):
         """
@@ -2227,7 +2726,7 @@ class Ldeep(Command):
 
         try:
             if self.engine.modify_password(user, curr, new):
-                info("Password of {username} changed".format(username=user))
+                info(f"Password of {user} changed")
             else:
                 error(
                     f"Unable to change {user}'s password, check domain password policy or privileges"
@@ -2407,7 +2906,6 @@ def main():
         action="store_true",
         help="Enable the retrieval of security descriptors in ldeep results",
     )
-
     sub = parser.add_subparsers(
         title="Mode",
         dest="mode",
@@ -2418,6 +2916,31 @@ def main():
 
     ldap = sub.add_parser("ldap", description="LDAP mode")
     cache = sub.add_parser("cache", description="Cache mode")
+    bloodhound = sub.add_parser(
+        "bloodhound",
+        description="Convert an existing ldeep cache to BloodHound JSON",
+    )
+    bloodhound.add_argument(
+        "-d",
+        "--dir",
+        default=".",
+        type=str,
+        help="Directory containing the ldeep cache",
+    )
+    bloodhound.add_argument(
+        "-p",
+        "--prefix",
+        required=True,
+        type=str,
+        help="Prefix of the ldeep cache files",
+    )
+    bloodhound.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        type=str,
+        help="Directory where bh_*.json files will be written",
+    )
     protections = sub.add_parser("protections", description="Protections mode")
     protections.add_argument(
         "-d", "--domain", required=True, help="The domain as NetBIOS or FQDN"
@@ -2537,12 +3060,32 @@ def main():
     Ldeep.add_subparsers(
         cache,
         "cache",
-        ["list_", "get_"],
+        ["list_", "get_", "misc_"],
         title="commands",
         description="available commands",
     )
 
     args = parser.parse_args()
+
+    if args.mode == "bloodhound":
+        try:
+            query_engine = CacheActiveDirectoryView(args.dir, args.prefix)
+            # The dedicated cache converter must keep security descriptors in
+            # memory.  CacheActiveDirectoryView otherwise scrubs them when
+            # ``ntSecurityDescriptor`` is not part of the requested attrs.
+            query_engine.set_all_attributes(
+                [ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES, "ntSecurityDescriptor"]
+            )
+            Ldeep(query_engine, format="bloodhound").misc_all(
+                {"output": args.output, "output_dir": True}
+            )
+        except (
+            CacheActiveDirectoryView.CacheActiveDirectoryDirNotFoundException,
+            CacheActiveDirectoryView.CacheActiveDirectoryFileNotFoundException,
+        ) as e:
+            error(e)
+            sys.exit(1)
+        return
 
     # Output
     if args.outfile:
@@ -2634,6 +3177,8 @@ def main():
         error(e)
     except NotImplementedError:
         error("Feature not yet available")
+    except ValueError as e:
+        error(e)
 
 
 if __name__ == "__main__":

--- a/ldeep/utils/__init__.py
+++ b/ldeep/utils/__init__.py
@@ -20,7 +20,7 @@ def get_key_for_value(dic, val):
     return next((k for k, v in dic.items() if v == val), None)
 
 
-class Logger(object):
+class Logger:
     def __init__(self, outfile=None, quiet=False):
         self.quiet = quiet
         self.terminal = __stdout__
@@ -35,10 +35,9 @@ class Logger(object):
     def flush(self):
         if self.log:
             self.log.flush()
-        pass
 
 
-class ResolverThread(object):
+class ResolverThread:
     def __init__(self, dns_server):
         self.dns_server = dns_server
         self.resolutions = []

--- a/ldeep/utils/bloodhound.py
+++ b/ldeep/utils/bloodhound.py
@@ -1,0 +1,2443 @@
+"""Conversion of ldeep Active Directory records to BloodHound JSON.
+
+BloodHound expects one JSON document per node type.  ldeep records are kept
+under ``Properties`` so that attributes which are not used by BloodHound are
+not lost during the conversion.
+"""
+
+import base64
+import hashlib
+import re
+from datetime import date, datetime, timezone
+from uuid import UUID, uuid5
+
+from ldeep._version import __version__
+from ldeep.utils.sddl import parse_ntSecurityDescriptor
+from ldeep.views.constants import (
+    MS_PKI_CERTIFICATE_NAME_FLAG,
+    MS_PKI_ENROLLMENT_FLAG,
+)
+
+BLOODHOUND_VERSION = 6
+BLOODHOUND_NODE_TYPES = (
+    "domains",
+    "gpos",
+    "ous",
+    "computers",
+    "groups",
+    "users",
+    "enterprisecas",
+    "certtemplates",
+    "containers",
+    "rootcas",
+    "aiacas",
+    "ntauthstores",
+    "issuancepolicies",
+)
+# The data is collected through LDAP/DC-only queries, like SharpHound's
+# DCOnly collection method.
+BLOODHOUND_METHODS = 262885
+
+_WELL_KNOWN_SIDS = {
+    "S-1-1-0",
+    "S-1-5-4",
+    "S-1-5-9",
+    "S-1-5-11",
+    "S-1-5-17",
+    "S-1-5-32-544",
+    "S-1-5-32-545",
+    "S-1-5-32-546",
+    "S-1-5-32-548",
+    "S-1-5-32-549",
+    "S-1-5-32-550",
+    "S-1-5-32-551",
+    "S-1-5-32-552",
+    "S-1-5-32-554",
+    "S-1-5-32-555",
+    "S-1-5-32-556",
+    "S-1-5-32-557",
+    "S-1-5-32-558",
+    "S-1-5-32-559",
+    "S-1-5-32-560",
+    "S-1-5-32-561",
+    "S-1-5-32-562",
+    "S-1-5-32-568",
+    "S-1-5-32-569",
+    "S-1-5-32-573",
+    "S-1-5-32-574",
+    "S-1-5-32-575",
+    "S-1-5-32-576",
+    "S-1-5-32-577",
+    "S-1-5-32-578",
+    "S-1-5-32-579",
+    "S-1-5-32-580",
+    "S-1-5-32-581",
+    "S-1-5-32-582",
+}
+
+_WELL_KNOWN_USER_SIDS = {"S-1-5-17"}
+
+_WELL_KNOWN_NAMES = {
+    "S-1-1-0": "EVERYONE",
+    "S-1-5-4": "INTERACTIVE",
+    "S-1-5-9": "ENTERPRISE DOMAIN CONTROLLERS",
+    "S-1-5-11": "AUTHENTICATED USERS",
+    "S-1-5-17": "IUSR",
+}
+
+_WELL_KNOWN_GROUP_NAMES = {
+    "S-1-5-32-552": "REPLICATORS",
+}
+
+_IGNORED_ACL_SIDS = {"S-1-3-0", "S-1-5-10", "S-1-5-18"}
+
+_ACL_GUIDS = {
+    "getchanges": "1131F6AA-9C07-11D1-F79F-00C04FC2DCD2",
+    "getchangesall": "1131F6AD-9C07-11D1-F79F-00C04FC2DCD2",
+    "getchangesinfilteredset": "89E95B76-444D-4C62-991A-0FACBEDA640C",
+    "writemember": "BF9679C0-0DE6-11D0-A285-00AA003049E2",
+    "forcechangepassword": "00299570-246D-11D0-A768-00AA006E0529",
+    "allowedtoact": "3F78C3E5-F79A-46BD-A0B8-9D18116DDC79",
+    "useraccountrestrictions": "4C164200-20C0-11D0-A768-00AA006E0529",
+    "writegplink": "F30E3BBE-9FF0-11D1-B603-0000F80367C1",
+    "keycredentiallink": "5B47D60F-6090-40B2-9F37-2A4DE88F3063",
+    "serviceprincipalname": "AB721A53-1E2F-11D0-9819-00AA0040529B",
+    "enroll": "0E10C968-78FB-11D2-90D4-00C04F79DC55",
+}
+
+# Windows LAPS uses a shared attribute-security GUID.  The legacy
+# ms-Mcs-AdmPwd GUID is schema-specific, so LDAP mode can override this set
+# with the GUIDs discovered from the directory schema.
+_LAPS_GUIDS = {
+    "F3531EC6-6330-4F8E-8D39-7A671FBAC605",
+    "50856756-E42A-40FE-AEAC-34FD9584E405",
+    "404FCC5F-B022-4D9D-963C-AAEE4038657B",
+}
+
+_OBJECT_CLASS_GUIDS = {
+    "domain": "19195A5B-6DA0-11D0-AFD3-00C04FD930C9",
+    "computer": "BF967A86-0DE6-11D0-A285-00AA003049E2",
+    "group": "BF967A9C-0DE6-11D0-A285-00AA003049E2",
+    "organizational-unit": "BF967AA5-0DE6-11D0-A285-00AA003049E2",
+    "user": "BF967ABA-0DE6-11D0-A285-00AA003049E2",
+    "gpo": "F30E3BC2-9FF0-11D1-B603-0000F80367C1",
+}
+
+_OBJECT_CLASS_TYPES = {
+    "domain": "domains",
+    "domaindns": "domains",
+    "computer": "computers",
+    "group": "groups",
+    "organizationalunit": "ous",
+    "grouppolicycontainer": "gpos",
+    "pkienrollmentservice": "enterprisecas",
+    "pkicertificatetemplate": "certtemplates",
+    "mspki-enterprise-oid": "issuancepolicies",
+    "user": "users",
+    "person": "users",
+}
+
+_SKIPPED_PROPERTIES = {
+    "dn",
+    "distinguishedname",
+    "name",
+    "objectclass",
+    "objectguid",
+    "objectsid",
+    "ntsecuritydescriptor",
+    "msds-supportedencryptiontypes",
+    "cacertificate",
+    "cacertificatedn",
+    "certificatetemplates",
+    "msds-managedpassword",
+    "nthash",
+    "aes128-cts-hmac-sha1-96",
+    "aes256-cts-hmac-sha1-96",
+}
+
+_CA_FLAGS = {
+    0x2: "SUPPORTS_NT_AUTHENTICATION",
+    0x8: "CA_SERVERTYPE_ADVANCED",
+}
+
+_UAC_FLAGS = {
+    "ACCOUNTDISABLE": 0x2,
+    "INTERDOMAIN_TRUST_ACCOUNT": 0x800,
+    "LOCKOUT": 0x10,
+    "PASSWD_NOTREQD": 0x20,
+    "PASSWD_CANT_CHANGE": 0x40,
+    "ENCRYPTED_TEXT_PWD_ALLOWED": 0x80,
+    "NORMAL_ACCOUNT": 0x200,
+    "WORKSTATION_TRUST_ACCOUNT": 0x1000,
+    "SERVER_TRUST_ACCOUNT": 0x2000,
+    "DONT_EXPIRE_PASSWORD": 0x10000,
+    "SMARTCARD_REQUIRED": 0x40000,
+    "TRUSTED_FOR_DELEGATION": 0x80000,
+    "NOT_DELEGATED": 0x100000,
+    "USE_DES_KEY_ONLY": 0x200000,
+    "DONT_REQ_PREAUTH": 0x400000,
+    "PASSWORD_EXPIRED": 0x800000,
+    "TRUSTED_TO_AUTH_FOR_DELEGATION": 0x1000000,
+}
+
+# ldeep gets the names of templates published by a CA, but does not query the
+# certificate-template objects themselves.  BloodHound still needs an object
+# identifier for the references in EnterpriseCA.EnabledCertTemplates.  UUID5
+# gives us a stable identifier without pretending that it is the AD objectGUID.
+_SYNTHETIC_NAMESPACE = UUID("2c7b7a6d-1a5d-5b1f-8ec7-9f3c6f3d0c9e")
+
+_BH_OBJECT_TYPES = {
+    "containers": "Container",
+    "configuration": "Configuration",
+    "certtemplates": "CertTemplate",
+    "rootcas": "RootCA",
+    "aiacas": "AiaCA",
+    "ntauthstores": "NTAuthStore",
+    "issuancepolicies": "IssuancePolicy",
+    "base": "Base",
+}
+
+
+def _first(value, default=None):
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else default
+    return value if value is not None else default
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _coerce_descriptor(value):
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, (str, bytes, bytearray)):
+        try:
+            return parse_ntSecurityDescriptor(base64.b64decode(value))
+        except Exception:
+            return None
+    return None
+
+
+def _record_first(record, *names, default=None):
+    """Read an LDAP attribute without depending on its JSON key casing."""
+    for name in names:
+        wanted = name.casefold()
+        for key, value in record.items():
+            if str(key).casefold() == wanted:
+                return _first(value, default)
+    return default
+
+
+def _record_value(record, *names, default=None):
+    wanted = {name.casefold() for name in names}
+    for key, value in record.items():
+        if str(key).casefold() in wanted:
+            return value
+    return default
+
+
+def _domain_from_dn(dn):
+    if not isinstance(dn, str):
+        return ""
+    parts = []
+    for component in dn.split(","):
+        key, separator, value = component.partition("=")
+        if separator and key.strip().lower() == "dc":
+            parts.append(value.strip())
+    return ".".join(parts)
+
+
+def _domain_dn(domain):
+    return ",".join(f"DC={part}" for part in domain.split(".") if part)
+
+
+def _synthetic_identifier(object_type, canonical_name):
+    return str(
+        uuid5(_SYNTHETIC_NAMESPACE, f"{object_type}|{canonical_name.casefold()}")
+    ).upper()
+
+
+def _published_template_entries(record, template_records=None):
+    """Return the published template names that ldeep collected for a CA."""
+    dn = record.get("distinguishedName") or record.get("dn") or ""
+    domain = _domain_from_dn(dn)
+    if not domain:
+        return []
+    domain_dn = _domain_dn(domain)
+    entries = []
+    seen = set()
+    for value in _as_list(record.get("certificateTemplates")):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        template_name = value.strip()
+        template_dn = (
+            f"CN={template_name},CN=Certificate Templates,CN=Public Key Services,"
+            f"CN=Services,CN=Configuration,{domain_dn}"
+        )
+        identifier = _synthetic_identifier("certtemplate", template_dn)
+        for template_record in template_records or []:
+            template_name_candidates = {
+                str(value).casefold()
+                for value in (
+                    _as_list(template_record.get("cn"))
+                    + _as_list(template_record.get("name"))
+                    + _as_list(template_record.get("displayName"))
+                )
+                if value is not None
+            }
+            if template_name.casefold() not in template_name_candidates:
+                continue
+            template_guid = _first(template_record.get("objectGUID"))
+            if template_guid:
+                identifier = _normalize_identifier(template_guid, domain)
+            break
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        entries.append(
+            {
+                "domain": domain,
+                "name": template_name,
+                "dn": template_dn,
+                "identifier": identifier,
+            }
+        )
+    return entries
+
+
+def _unresolved_published_templates(record, template_records=None):
+    """Return only CA-published template names absent from the LDAP dump."""
+    names = [
+        value.strip()
+        for value in _as_list(record.get("certificateTemplates"))
+        if isinstance(value, str) and value.strip()
+    ]
+    if not template_records:
+        return names
+    known = set()
+    for template_record in template_records:
+        for value in (
+            _as_list(template_record.get("cn"))
+            + _as_list(template_record.get("name"))
+            + _as_list(template_record.get("displayName"))
+        ):
+            if value is not None:
+                known.add(str(value).casefold())
+    return [name for name in names if name.casefold() not in known]
+
+
+def _domain_sid(sid):
+    if isinstance(sid, str) and sid.upper().startswith("S-1-5-21-"):
+        parts = sid.split("-")
+        if len(parts) >= 7:
+            return "-".join(parts[:7])
+    return ""
+
+
+def _normalize_identifier(identifier, domain):
+    if not isinstance(identifier, str):
+        return identifier
+    if identifier in _WELL_KNOWN_SIDS and domain:
+        return f"{domain.upper()}-{identifier}"
+    if identifier.startswith("{"):
+        return identifier.strip("{}").upper()
+    return identifier
+
+
+def _guid(value):
+    if not isinstance(value, str):
+        return ""
+    return value.strip("{}").upper()
+
+
+def _as_timestamp(value):
+    """Return a BloodHound-compatible Unix timestamp where possible."""
+    value = _first(value)
+    if isinstance(value, datetime):
+        return max(0, int(value.timestamp()))
+    if isinstance(value, date):
+        return max(
+            0,
+            int(
+                datetime(
+                    value.year,
+                    value.month,
+                    value.day,
+                    tzinfo=timezone.utc,
+                ).timestamp()
+            ),
+        )
+    if isinstance(value, int):
+        # AD FILETIME is the number of 100ns intervals since 1601.
+        if value > 10**12:
+            return int((value - 116444736000000000) / 10**7)
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+        return max(0, int(parsed.timestamp()))
+    return value
+
+
+def _ad_duration(value, zero="", forever=False):
+    """Convert an AD 100 ns duration to BloodHound's display format."""
+    value = _first(value)
+    if not isinstance(value, int):
+        return value
+    if value == -9223372036854775808 and forever:
+        return "Forever"
+    if value == 0:
+        return zero
+    seconds = abs(value) // 10**7
+    if seconds == 0:
+        return zero
+    units = (
+        (86400, "day"),
+        (3600, "hour"),
+        (60, "minute"),
+        (1, "second"),
+    )
+    for divisor, label in units:
+        if seconds % divisor == 0:
+            amount = seconds // divisor
+            return f"{amount} {label}{'' if amount == 1 else 's'}"
+    return f"{seconds} seconds"
+
+
+def _password_properties(value):
+    value = _first(value)
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return value
+    flags = {
+        "DOMAIN_PASSWORD_COMPLEX": 0x1,
+        "DOMAIN_PASSWORD_NO_ANON_CHANGE": 0x2,
+        "DOMAIN_PASSWORD_NO_CLEAR_CHANGE": 0x4,
+        "DOMAIN_LOCKOUT_ADMINS": 0x8,
+        "DOMAIN_PASSWORD_STORE_CLEARTEXT": 0x10,
+        "DOMAIN_REFUSE_PASSWORD_CHANGE": 0x20,
+    }
+    return sum(flags.get(item.strip(), 0) for item in value.split("|"))
+
+
+def _flag_names(value, mapping):
+    value = _first(value)
+    if not isinstance(value, int):
+        return value
+    names = [
+        name
+        for name, bit in mapping.items()
+        if (bit == 0 and value == 0) or (bit and value & bit)
+    ]
+    return ", ".join(names) if names else "NONE"
+
+
+def _ad_duration_from_bytes(value):
+    if not isinstance(value, str):
+        return _ad_duration(value)
+    try:
+        decoded = base64.b64decode(value)
+        raw = int.from_bytes(decoded, "little", signed=True)
+    except (ValueError, TypeError):
+        return value
+    seconds = abs(raw) // 10**7
+    if seconds and seconds % (365 * 86400) == 0:
+        amount = seconds // (365 * 86400)
+        return f"{amount} year{'' if amount == 1 else 's'}"
+    if seconds and seconds % (7 * 86400) == 0:
+        amount = seconds // (7 * 86400)
+        return f"{amount} week{'' if amount == 1 else 's'}"
+    return _ad_duration(raw)
+
+
+def _uac_contains(value, flag):
+    value = _first(value, "")
+    if isinstance(value, str):
+        return flag in {item.strip() for item in value.split("|")}
+    if isinstance(value, int):
+        return bool(value & _UAC_FLAGS.get(flag, 0))
+    return False
+
+
+def _uac_value(value):
+    value = _first(value)
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return value
+    result = 0
+    for flag in value.split("|"):
+        result |= _UAC_FLAGS.get(flag.strip(), 0)
+    return result
+
+
+def _encryption_types(value):
+    value = _first(value)
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, str):
+        if value.strip().upper() == "NONE":
+            return ["Not defined"]
+        names = {
+            "RC4-HMAC": "RC4-HMAC-MD5",
+            "RC4-HMAC-MD5": "RC4-HMAC-MD5",
+            "AES128-CTS-HMAC-SHA1-96": "AES128-CTS-HMAC-SHA1-96",
+            "AES256-CTS-HMAC-SHA1-96": "AES256-CTS-HMAC-SHA1-96",
+            "DES-CBC-CRC": "DES-CBC-CRC",
+            "DES-CBC-MD5": "DES-CBC-MD5",
+        }
+        return [names.get(item.strip(), item.strip()) for item in value.split("|")]
+    if isinstance(value, int):
+        flags = (
+            (0x1, "DES-CBC-CRC"),
+            (0x2, "DES-CBC-MD5"),
+            (0x4, "RC4-HMAC-MD5"),
+            (0x8, "AES128-CTS-HMAC-SHA1-96"),
+            (0x10, "AES256-CTS-HMAC-SHA1-96"),
+        )
+        return [name for flag, name in flags if value & flag]
+    return []
+
+
+def _certificate_properties(record):
+    """Extract the certificate fields BloodHound exposes for an Enterprise CA."""
+    encoded = _record_first(record, "cACertificate")
+    if not isinstance(encoded, str):
+        return {}
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes
+
+        certificate = x509.load_der_x509_certificate(base64.b64decode(encoded))
+        thumbprint = certificate.fingerprint(hashes.SHA1()).hex().upper()
+        try:
+            basic_constraints = certificate.extensions.get_extension_for_class(
+                x509.BasicConstraints
+            ).value
+            path_length = basic_constraints.path_length
+        except x509.ExtensionNotFound:
+            path_length = None
+        return {
+            "certchain": [thumbprint],
+            "certname": thumbprint,
+            "certthumbprint": thumbprint,
+            # SharpHound reports this as true only when a concrete path
+            # length is present, while keeping the displayed length at 0.
+            "hasbasicconstraints": path_length is not None,
+            "basicconstraintpathlength": path_length or 0,
+        }
+    except Exception:
+        return {}
+
+
+def _certificate_template_properties(record):
+    """Map ldeep's raw ADCS template attributes to SharpHound names."""
+    name_flags = _record_value(record, "msPKI-Certificate-Name-Flag")
+    enrollment_flags = _record_value(record, "msPKI-Enrollment-Flag")
+    name_flags_value = _first(name_flags, 0)
+    enrollment_flags_value = _first(enrollment_flags, 0)
+    ekus = _as_list(_record_value(record, "pKIExtendedKeyUsage"))
+    certificate_application_policies = _as_list(
+        _record_value(record, "msPKI-Certificate-Application-Policy")
+    )
+    ra_policies = _as_list(_record_value(record, "msPKI-RA-Application-Policies"))
+    application_policies = [
+        value
+        for value in ra_policies
+        if isinstance(value, str) and re.fullmatch(r"\d+(?:\.\d+)+", value)
+    ]
+    authenticating_ekus = {
+        "1.3.6.1.5.5.7.3.2",
+        "1.3.6.1.5.2.3.4",
+        "1.3.6.1.4.1.311.20.2.2",
+        "2.5.29.37.0",
+    }
+    result = {
+        "oid": _record_first(record, "msPKI-Cert-Template-OID"),
+        "certificatenameflag": _flag_names(
+            name_flags_value, MS_PKI_CERTIFICATE_NAME_FLAG
+        ),
+        "enrollmentflag": _flag_names(enrollment_flags_value, MS_PKI_ENROLLMENT_FLAG),
+        "ekus": ekus,
+        "effectiveekus": ekus,
+        "certificateapplicationpolicy": certificate_application_policies,
+        "applicationpolicies": application_policies,
+        "certificatepolicy": _as_list(_record_value(record, "certificatePolicies")),
+        "issuancepolicies": [],
+        "enrolleesuppliessubject": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["ENROLLEE_SUPPLIES_SUBJECT"]
+        ),
+        "subjectaltrequireupn": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_ALT_REQUIRE_UPN"]
+        ),
+        "subjectaltrequireemail": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_ALT_REQUIRE_EMAIL"]
+        ),
+        "subjectaltrequirespn": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_ALT_REQUIRE_SPN"]
+        ),
+        "subjectaltrequiredns": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_ALT_REQUIRE_DNS"]
+        ),
+        "subjectaltrequiredomaindns": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value
+            & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_ALT_REQUIRE_DOMAIN_DNS"]
+        ),
+        "subjectrequireemail": bool(
+            isinstance(name_flags_value, int)
+            and name_flags_value & MS_PKI_CERTIFICATE_NAME_FLAG["SUBJECT_REQUIRE_EMAIL"]
+        ),
+        "requiresmanagerapproval": bool(
+            isinstance(enrollment_flags_value, int)
+            and enrollment_flags_value & MS_PKI_ENROLLMENT_FLAG["PEND_ALL_REQUESTS"]
+        ),
+        "authorizedsignatures": _record_first(record, "msPKI-RA-Signature", default=0),
+        "schemaversion": _record_first(record, "msPKI-Template-Schema-Version"),
+        "nosecurityextension": bool(
+            isinstance(enrollment_flags_value, int)
+            and enrollment_flags_value & MS_PKI_ENROLLMENT_FLAG["NO_SECURITY_EXTENSION"]
+        ),
+        "authenticationenabled": bool(authenticating_ekus & set(ekus))
+        or "CERTIFICATION AUTHORITY"
+        in str(_record_first(record, "displayName", "cn", default="")).upper(),
+        "schannelauthenticationenabled": bool(authenticating_ekus & set(ekus))
+        or "CERTIFICATION AUTHORITY"
+        in str(_record_first(record, "displayName", "cn", default="")).upper(),
+        "validityperiod": _ad_duration_from_bytes(
+            _record_value(record, "pKIExpirationPeriod")
+        ),
+        "renewalperiod": _ad_duration_from_bytes(
+            _record_value(record, "pKIOverlapPeriod")
+        ),
+    }
+    return {key: value for key, value in result.items() if value is not None}
+
+
+def _ca_flags(value):
+    value = _first(value)
+    if not isinstance(value, int):
+        return value
+    return ", ".join(name for bit, name in _CA_FLAGS.items() if value & bit)
+
+
+def _object_type(record):
+    classes = record.get("objectClass", [])
+    if isinstance(classes, str):
+        classes = [classes]
+    normalized_classes = {str(object_class).lower() for object_class in classes}
+    # Computer objects also inherit from user/person, so test the more
+    # specific classes before the generic ones.  A gMSA also carries the
+    # ``computer`` class in AD, but BloodHound models it as a User node.
+    if normalized_classes & {
+        "msds-groupmanagedserviceaccount",
+        "msds-managedserviceaccount",
+    }:
+        return "users"
+    for object_class in (
+        "domaindns",
+        "domain",
+        "computer",
+        "group",
+        "organizationalunit",
+        "grouppolicycontainer",
+        "pkienrollmentservice",
+        "pkicertificatetemplate",
+        "mspki-enterprise-oid",
+        "user",
+        "person",
+    ):
+        if object_class in normalized_classes:
+            return _OBJECT_CLASS_TYPES[object_class]
+    sam_account_name = _first(record.get("sAMAccountName"), "")
+    if isinstance(sam_account_name, str) and sam_account_name.endswith("$"):
+        return "computers"
+    return None
+
+
+def configuration_object_type(record):
+    """Classify objects returned by ldeep's Configuration-partition dump.
+
+    ``conf`` is intentionally a broad LDAP dump.  BloodHound gives several
+    PKI objects their own node type, while AD itself represents some of them
+    as ordinary containers.  Prefer the explicit object class and then use
+    the well-known PKI container DN when the class is generic.
+    """
+    classes = {str(value).lower() for value in _as_list(record.get("objectClass"))}
+    dn = str(record.get("distinguishedName") or record.get("dn") or "")
+    dn_lower = dn.lower()
+    first_rdn = dn_lower.split(",", 1)[0]
+
+    if "pkicertificatetemplate" in classes:
+        return "certtemplates"
+    if "mspki-enterprise-oid" in classes:
+        if first_rdn == "cn=oid":
+            return "containers"
+        return "issuancepolicies" if _is_issuance_policy(record) else None
+    if "pkienrollmentservice" in classes:
+        return "enterprisecas"
+    if "configuration" in classes:
+        return "containers"
+
+    # These are the standard ADCS configuration containers.  An object below
+    # them is represented as a dedicated BloodHound node when its DN makes
+    # that unambiguous.
+    if first_rdn == "cn=ntauthcertificates":
+        return "ntauthstores"
+    if "cn=ntauthcertificates," in dn_lower:
+        # The NTAuthStore node owns the certificates below it; those child
+        # records are not separate BloodHound NTAuthStore objects.
+        return None
+    if "cn=aia," in dn_lower:
+        return "aiacas" if "container" not in classes else "containers"
+    if "cn=certification authorities," in dn_lower:
+        return "rootcas" if "container" not in classes else "containers"
+    if "container" in classes or "builtinDomain".lower() in classes:
+        return "containers"
+    return None
+
+
+def _configuration_identifier(record, object_type):
+    """Return a stable identifier for a Configuration object.
+
+    Real AD objectGUIDs are always preferred.  The UUID5 fallback is only for
+    malformed/incomplete cache records and is explicitly marked synthetic by
+    the caller.
+    """
+    object_guid = _first(record.get("objectGUID"))
+    if object_guid:
+        return _normalize_identifier(object_guid, "")
+    dn = record.get("distinguishedName") or record.get("dn") or ""
+    return _synthetic_identifier(object_type, str(dn))
+
+
+def _configuration_parent(record, configuration_records, domain_sid=""):
+    dn = str(record.get("distinguishedName") or record.get("dn") or "")
+    parent_dn = dn.split(",", 1)[1] if "," in dn else ""
+    for candidate in configuration_records or []:
+        candidate_dn = str(
+            candidate.get("distinguishedName") or candidate.get("dn") or ""
+        )
+        if candidate_dn.casefold() != parent_dn.casefold():
+            continue
+        candidate_classes = {
+            str(value).casefold() for value in _as_list(candidate.get("objectClass"))
+        }
+        candidate_first_rdn = candidate_dn.casefold().split(",", 1)[0]
+        if "configuration" in candidate_classes:
+            object_type = "configuration"
+        elif candidate_first_rdn == "cn=oid":
+            # SharpHound keeps OID children attached to a Base node even
+            # though the OID container itself is emitted as a Container.
+            object_type = "base"
+        else:
+            object_type = configuration_object_type(candidate)
+        object_guid = _first(candidate.get("objectGUID"))
+        if not object_guid:
+            # Do not create a synthetic parent merely to complete a graph
+            # edge. A parent without an objectGUID is not safe to identify.
+            continue
+        if object_type is None:
+            object_type = (
+                "configuration" if "configuration" in candidate_classes else "base"
+            )
+        return {
+            "ObjectIdentifier": _configuration_identifier(candidate, object_type),
+            "ObjectType": _BH_OBJECT_TYPES.get(object_type, object_type),
+        }
+    if parent_dn and all(
+        component.strip().casefold().startswith("dc=")
+        for component in parent_dn.split(",")
+    ):
+        return {"ObjectIdentifier": domain_sid, "ObjectType": "Domain"}
+    return None
+
+
+def _core_parent(record, candidates, domain_sid):
+    dn = str(record.get("distinguishedName") or record.get("dn") or "")
+    parent_dn = dn.split(",", 1)[1] if "," in dn else ""
+    if parent_dn.casefold().startswith("cn=builtin,") and all(
+        component.strip().casefold().startswith("dc=")
+        for component in parent_dn.split(",", 1)[1:]
+    ):
+        return {"ObjectIdentifier": domain_sid, "ObjectType": "Domain"}
+    for candidate in candidates or []:
+        candidate_dn = str(
+            candidate.get("distinguishedName") or candidate.get("dn") or ""
+        )
+        if candidate_dn.casefold() != parent_dn.casefold():
+            continue
+        candidate_type = _object_type(candidate)
+        if candidate_type == "ous":
+            return {
+                "ObjectIdentifier": _normalize_identifier(
+                    _first(candidate.get("objectGUID")),
+                    _domain_from_dn(candidate_dn),
+                ),
+                "ObjectType": "OU",
+            }
+        if candidate_type == "domains":
+            return {
+                "ObjectIdentifier": _first(candidate.get("objectSid"), domain_sid),
+                "ObjectType": "Domain",
+            }
+        if candidate_type == "containers":
+            identifier = _configuration_identifier(candidate, "containers")
+            if identifier:
+                return {
+                    "ObjectIdentifier": identifier,
+                    "ObjectType": "Container",
+                }
+    if parent_dn and all(
+        component.strip().casefold().startswith("dc=")
+        for component in parent_dn.split(",")
+    ):
+        return {"ObjectIdentifier": domain_sid, "ObjectType": "Domain"}
+    return None
+
+
+def _configuration_name(record, domain):
+    name = _first(record.get("cn"), _first(record.get("name"), ""))
+    if not name:
+        name = _first(record.get("displayName"), "")
+    name = str(name)
+    return f"{name}@{domain}".upper().strip("@") if domain else name.upper()
+
+
+def _gpo_links(record, gpo_records=None):
+    """Translate gPLink GUIDs (GPO CNs) to GPO objectGUIDs."""
+    raw = _record_value(record, "gPLink")
+    if not raw:
+        return []
+    raw = _first(raw)
+    if not isinstance(raw, str):
+        return []
+    by_cn = {}
+    for gpo in gpo_records or []:
+        cn = _record_first(gpo, "cn")
+        identifier = _record_first(gpo, "objectGUID")
+        if cn and identifier:
+            by_cn[str(cn).strip("{}").casefold()] = _normalize_identifier(
+                str(identifier), ""
+            )
+    links = []
+    for guid, options in re.findall(r"\{([^}]+)\}[^;]*;(\d+)", raw):
+        identifier = by_cn.get(guid.casefold())
+        if not identifier:
+            continue
+        links.append(
+            {
+                "IsEnforced": bool(int(options) & 0x2),
+                "GUID": identifier,
+            }
+        )
+    return links
+
+
+def _gpo_link_specs(record):
+    """Return the linked GPO GUIDs and their link options."""
+    raw = _first(_record_value(record, "gPLink"))
+    if not isinstance(raw, str):
+        return []
+    return [
+        (guid.upper(), int(options))
+        for guid, options in re.findall(r"\{([^}]+)\}[^;]*;(\d+)", raw)
+    ]
+
+
+def _affected_computers(
+    record,
+    object_type,
+    computer_records=None,
+):
+    """Return computers below a domain/OU with at least one active GPO link.
+
+    SharpHound exposes this relationship on domains and OUs.  The LDAP data
+    already contains the GPO links and the computer DNs, so this is a graph
+    calculation rather than a new collection.
+    """
+    if object_type not in {"domains", "ous"}:
+        return []
+    links = [options for _, options in _gpo_link_specs(record)]
+    if not any(not options & 0x1 for options in links):
+        return []
+
+    target_dn = str(record.get("distinguishedName") or record.get("dn") or "")
+    target_dn = target_dn.casefold()
+    result = []
+    seen = set()
+    for computer in computer_records or []:
+        computer_dn = str(computer.get("distinguishedName") or computer.get("dn") or "")
+        parent_dn = computer_dn.split(",", 1)[1] if "," in computer_dn else ""
+        is_below = (
+            object_type == "domains"
+            and target_dn == _domain_dn(_domain_from_dn(computer_dn)).casefold()
+        )
+        while parent_dn and not is_below:
+            if parent_dn.casefold() == target_dn:
+                is_below = True
+                break
+            parent_dn = parent_dn.split(",", 1)[1] if "," in parent_dn else ""
+        if not is_below:
+            continue
+        sid = _first(computer.get("objectSid"))
+        if not sid:
+            continue
+        identifier = _normalize_identifier(sid, _domain_from_dn(computer_dn))
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        result.append({"ObjectIdentifier": identifier, "ObjectType": "Computer"})
+    return result
+
+
+def _is_issuance_policy(record):
+    """Distinguish issuance-policy OIDs from ordinary PKI OID objects."""
+    value = _first(record.get("flags"))
+    if isinstance(value, str):
+        try:
+            value = int(value, 0)
+        except ValueError:
+            return "ISSUANCE" in value.upper()
+    return isinstance(value, int) and bool(value & 0x2)
+
+
+def _object_name(record, object_type, domain):
+    sam = _first(record.get("sAMAccountName"), "")
+    if object_type == "computers":
+        name = _first(record.get("dNSHostName"))
+        if name:
+            return str(name).upper()
+        return f"{str(sam).rstrip('$')}.{domain}".upper().strip(".")
+    if object_type == "domains":
+        return domain.upper()
+    if object_type == "gpos":
+        name = _first(record.get("displayName"), _first(record.get("name"), ""))
+    elif object_type == "enterprisecas":
+        name = _first(record.get("cn"), _first(record.get("name"), ""))
+    elif object_type in {
+        "containers",
+        "certtemplates",
+        "rootcas",
+        "aiacas",
+        "ntauthstores",
+    }:
+        return _configuration_name(record, domain)
+    elif object_type == "issuancepolicies":
+        name = _record_first(record, "displayName", "cn", "name", default="")
+        return f"{name}@{domain}".upper().strip("@") if domain else str(name).upper()
+    elif object_type == "ous":
+        name = _first(record.get("name"), _first(record.get("ou"), ""))
+    elif object_type == "groups":
+        sid = _first(record.get("objectSid"), "")
+        name = _WELL_KNOWN_GROUP_NAMES.get(sid, sam or _first(record.get("name"), ""))
+    else:
+        name = sam or _first(record.get("name"), "")
+    name = str(name)
+    return f"{name}@{domain}".upper().strip("@") if domain else name.upper()
+
+
+def _ace_type(ace):
+    ace_type = str(ace.get("Type", ""))
+    return "Denied" if "Denied" in ace_type else "Allowed"
+
+
+_AD_RIGHTS_FLAGS = (
+    (0x1, "CreateChild"),
+    (0x2, "DeleteChild"),
+    (0x4, "ListChildren"),
+    (0x8, "Self"),
+    (0x10, "ReadProperty"),
+    (0x20, "WriteProperty"),
+    (0x40, "DeleteTree"),
+    (0x80, "ListObject"),
+    (0x100, "ExtendedRight"),
+    (0xF01FF, "GenericAll"),
+    (0x10000, "Delete"),
+    (0x20000, "ReadControl"),
+    (0x20004, "GenericExecute"),
+    (0x20028, "GenericWrite"),
+    (0x20094, "GenericRead"),
+    (0x40000, "WriteDacl"),
+    (0x80000, "WriteOwner"),
+    (0x100000, "Synchronize"),
+    (0x1000000, "AccessSystemSecurity"),
+)
+
+
+def _ad_rights_name(value):
+    """Render an AD rights mask like ActiveDirectoryRights.ToString()."""
+    if not isinstance(value, int):
+        return ""
+    remaining = value
+    selected = set()
+    # Enum.ToString decomposes a Flags value using the largest named values
+    # first.  This matters for masks such as GenericAll minus DeleteChild:
+    # GenericRead is selected as a named composite rather than expanded.
+    for bit, name in sorted(_AD_RIGHTS_FLAGS, reverse=True):
+        if bit and remaining & bit == bit:
+            selected.add(name)
+            remaining &= ~bit
+    if remaining:
+        return ""
+    names = [name for _, name in _AD_RIGHTS_FLAGS if name in selected]
+    return ", ".join(names)
+
+
+def _ace_inheritance_hash(ace):
+    """Calculate SharpHound's hash for one ACE."""
+    if ace.get("Raw Type") not in (0, 5):
+        return ""
+    sid = ace.get("SID")
+    if not sid or sid in _IGNORED_ACL_SIDS:
+        return ""
+    rights = _ad_rights_name(ace.get("Raw Access Required", 0))
+    if not rights:
+        return ""
+    empty_guid = "00000000-0000-0000-0000-000000000000"
+    object_type = _guid(ace.get("GUID")).lower() or empty_guid
+    inherited_object_type = _guid(ace.get("Inherited GUID")).lower() or empty_guid
+    value = sid + rights + object_type + inherited_object_type
+    return hashlib.sha1(value.encode("utf-8")).hexdigest().upper()
+
+
+def _inheritance_hash(ace):
+    """Calculate the hash of an explicit ACE that propagates inheritance."""
+    flags = ace.get("Raw Flags", 0)
+    if not isinstance(flags, int) or flags & 0x10 or not flags & 0x3:
+        return ""
+    return _ace_inheritance_hash(ace)
+
+
+def _inheritance_hashes(record):
+    descriptor = _security_descriptor(record)
+    if not isinstance(descriptor, dict):
+        return []
+    hashes = []
+    for ace in descriptor.get("DACL", {}).get("ACEs", []):
+        value = _inheritance_hash(ace)
+        if value:
+            hashes.append(value)
+    return hashes
+
+
+def _principal_type(sid, resolve_principal=None):
+    if not isinstance(sid, str):
+        return "Unknown"
+    if sid in _WELL_KNOWN_USER_SIDS:
+        return "User"
+    if any(sid.endswith(known_sid) for known_sid in _WELL_KNOWN_SIDS):
+        return "Group"
+    if sid.endswith(
+        (
+            "-498",
+            "-512",
+            "-513",
+            "-514",
+            "-515",
+            "-516",
+            "-517",
+            "-518",
+            "-519",
+            "-520",
+            "-521",
+            "-522",
+            "-526",
+            "-527",
+        )
+    ):
+        return "Group"
+    if resolve_principal:
+        resolved = resolve_principal(sid)
+        if isinstance(resolved, dict):
+            if "msds-groupmanagedserviceaccount" in {
+                str(value).casefold() for value in _as_list(resolved.get("objectClass"))
+            }:
+                # BloodHound models a gMSA as a User principal in ACLs,
+                # although its membership edge is represented as Computer.
+                return "User"
+            member_type = _member_type(resolved)
+            if member_type != "Unknown":
+                return member_type
+    # Do not turn an unresolved ACL principal into a User.  In particular,
+    # owner SIDs and principals from another trust are commonly absent from
+    # an LDAP-only cache and BloodHound models those as Base principals.
+    return "Base"
+
+
+def _entry_class(object_type):
+    return {
+        "domains": "domain",
+        "computers": "computer",
+        "groups": "group",
+        "ous": "organizational-unit",
+        "gpos": "gpo",
+        "users": "user",
+        "enterprisecas": "enterprise-ca",
+        "containers": "container",
+        "certtemplates": "cert-template",
+        "rootcas": "certification-authority",
+        "aiacas": "certification-authority",
+        "ntauthstores": "certification-authority",
+        "issuancepolicies": "issuance-policy",
+    }.get(object_type, "")
+
+
+def _aces(
+    record,
+    object_type,
+    domain,
+    resolve_principal=None,
+    object_type_guids=None,
+):
+    descriptor = _security_descriptor(record)
+    if not isinstance(descriptor, dict):
+        return []
+    dacl = descriptor.get("DACL", {})
+    result = []
+    seen_relations = set()
+
+    def add_relation(sid, right_name, inherited=False, inheritance_hash=""):
+        if not sid or sid in _IGNORED_ACL_SIDS:
+            return
+        normalized_sid = _normalize_identifier(sid, domain)
+        relation_key = (normalized_sid, right_name, inherited)
+        if relation_key in seen_relations:
+            if inherited and inheritance_hash:
+                for relation in result:
+                    if (
+                        relation["PrincipalSID"],
+                        relation["RightName"],
+                        relation["IsInherited"],
+                    ) == relation_key:
+                        relation["InheritanceHash"] = inheritance_hash
+                        break
+            return
+        seen_relations.add(relation_key)
+        result.append(
+            {
+                "PrincipalSID": normalized_sid,
+                "PrincipalType": _principal_type(sid, resolve_principal),
+                "RightName": right_name,
+                "IsInherited": inherited,
+                "InheritanceHash": inheritance_hash if inherited else "",
+                "IsPermissionForOwnerRightsSid": False,
+                "IsInheritedPermissionForOwnerRightsSid": False,
+            }
+        )
+
+    owner_sid = descriptor.get("Owner SID")
+    if owner_sid not in _IGNORED_ACL_SIDS:
+        add_relation(owner_sid, "Owns")
+
+    entry_class = _entry_class(object_type)
+    class_guid = _OBJECT_CLASS_GUIDS.get(entry_class)
+    classes = {
+        str(value).lower() for value in _as_list(_record_value(record, "objectClass"))
+    }
+    special_account = "msds-groupmanagedserviceaccount" in classes or _uac_contains(
+        _record_value(record, "userAccountControl"),
+        "INTERDOMAIN_TRUST_ACCOUNT",
+    )
+    is_domain_controller = _record_first(record, "primaryGroupID", default=0) == 516
+    haslaps = any(
+        _record_value(record, attribute) is not None
+        for attribute in (
+            "ms-Mcs-AdmPwd",
+            "ms-Mcs-AdmPwdExpirationTime",
+            "msLAPS-Password",
+            "msLAPS-PasswordExpirationTime",
+            "msLAPS-EncryptedPassword",
+            "msLAPS-EncryptedPasswordExpirationTime",
+        )
+    )
+    schema_guids = {
+        str(key).lower(): _guid(value)
+        for key, value in (object_type_guids or {}).items()
+        if value
+    }
+    laps_guids = set(_LAPS_GUIDS)
+    laps_guids.update(
+        value
+        for key, value in schema_guids.items()
+        if key
+        in {
+            "ms-mcs-admpwd",
+            "ms-laps-password",
+            "ms-laps-encryptedpassword",
+            "ms-laps-encryptedpasswordhistory",
+            "ms-laps-encryptedpasswordattributes",
+        }
+    )
+    generic_write_types = {
+        "user",
+        "group",
+        "computer",
+        "domain",
+        "gpo",
+        "organizational-unit",
+        "enterprise-ca",
+        "cert-template",
+        "certification-authority",
+        "issuance-policy",
+    }
+    for ace in dacl.get("ACEs", []):
+        sid = ace.get("SID")
+        if not sid or sid in _IGNORED_ACL_SIDS:
+            continue
+        if ace.get("Raw Type") not in (0, 5):
+            continue
+        flags = ace.get("Raw Flags", 0)
+        inherited = bool(flags & 0x10)
+        if not inherited and flags & 0x8:
+            continue
+
+        inherited_guid = _guid(ace.get("Inherited GUID"))
+        if inherited and inherited_guid and class_guid and inherited_guid != class_guid:
+            continue
+
+        access = ace.get("Raw Access Required", 0)
+        inheritance_hash = _ace_inheritance_hash(ace)
+        object_guid = _guid(ace.get("GUID"))
+        object_flags = ace.get("Raw Object Flags", 0)
+        object_type_present = bool(object_flags & 0x1)
+
+        # A generic right restricted to another object class does not apply
+        # to the current record.
+        if (
+            ace.get("Raw Type") == 5
+            and object_type_present
+            and class_guid
+            and object_guid not in {class_guid}
+            and access & 0xF01FF == 0xF01FF
+        ):
+            continue
+
+        if (
+            entry_class == "computer"
+            and haslaps
+            and object_type_present
+            and object_guid in laps_guids
+            and access & 0xF01FF == 0xF01FF
+        ):
+            add_relation(sid, "ReadLAPSPassword", inherited, inheritance_hash)
+            continue
+
+        if access & 0xF01FF == 0xF01FF:
+            add_relation(sid, "GenericAll", inherited, inheritance_hash)
+            continue
+
+        if access & 0x20028 == 0x20028 and entry_class in generic_write_types:
+            add_relation(sid, "GenericWrite", inherited, inheritance_hash)
+
+        if access & 0x40000:
+            add_relation(sid, "WriteDacl", inherited, inheritance_hash)
+        if access & 0x80000:
+            add_relation(sid, "WriteOwner", inherited, inheritance_hash)
+
+        write_property = bool(access & 0x20)
+        read_property = bool(access & 0x10)
+        control_access = bool(access & 0x100)
+        if (
+            entry_class == "computer"
+            and haslaps
+            and object_type_present
+            and object_guid in laps_guids
+            and read_property
+        ):
+            add_relation(sid, "ReadLAPSPassword", inherited, inheritance_hash)
+        if write_property:
+            if not object_type_present and entry_class in generic_write_types:
+                add_relation(sid, "GenericWrite", inherited, inheritance_hash)
+            if entry_class == "group" and object_guid == _ACL_GUIDS["writemember"]:
+                add_relation(sid, "AddMember", inherited, inheritance_hash)
+            if entry_class == "computer" and object_guid == _ACL_GUIDS["allowedtoact"]:
+                add_relation(sid, "AddAllowedToAct", inherited, inheritance_hash)
+            if (
+                entry_class in {"computer", "user"}
+                and not special_account
+                and object_guid == _ACL_GUIDS["useraccountrestrictions"]
+            ):
+                add_relation(
+                    sid, "WriteAccountRestrictions", inherited, inheritance_hash
+                )
+            if (
+                entry_class == "organizational-unit"
+                and object_guid == _ACL_GUIDS["writegplink"]
+            ):
+                add_relation(sid, "WriteGPLink", inherited, inheritance_hash)
+            if (
+                entry_class in {"computer", "user"}
+                and object_guid == _ACL_GUIDS["keycredentiallink"]
+            ):
+                add_relation(sid, "AddKeyCredentialLink", inherited, inheritance_hash)
+            if (
+                entry_class in {"computer", "user"}
+                and object_guid == _ACL_GUIDS["serviceprincipalname"]
+            ):
+                add_relation(sid, "WriteSPN", inherited, inheritance_hash)
+        elif access & 0x8:
+            if entry_class == "group" and object_guid == _ACL_GUIDS["writemember"]:
+                add_relation(sid, "AddSelf", inherited, inheritance_hash)
+
+        if control_access:
+            if not object_type_present and (
+                (
+                    entry_class in {"user", "domain"}
+                    and (not special_account or inherited)
+                )
+                or (
+                    entry_class == "computer" and inherited and not is_domain_controller
+                )
+            ):
+                add_relation(sid, "AllExtendedRights", inherited, inheritance_hash)
+            if entry_class == "domain":
+                for key, right_name in (
+                    ("getchanges", "GetChanges"),
+                    ("getchangesall", "GetChangesAll"),
+                    ("getchangesinfilteredset", "GetChangesInFilteredSet"),
+                ):
+                    if object_type_present and object_guid == _ACL_GUIDS[key]:
+                        add_relation(sid, right_name, inherited, inheritance_hash)
+            if entry_class in {"computer", "user"} and (
+                object_type_present and object_guid == _ACL_GUIDS["forcechangepassword"]
+            ):
+                add_relation(sid, "ForceChangePassword", inherited, inheritance_hash)
+            if entry_class == "enterprise-ca":
+                if object_guid == _ACL_GUIDS["enroll"]:
+                    add_relation(sid, "Enroll", inherited, inheritance_hash)
+                elif not object_type_present:
+                    add_relation(sid, "ManageCA", inherited, inheritance_hash)
+            elif entry_class == "cert-template" and object_guid == _ACL_GUIDS["enroll"]:
+                add_relation(sid, "Enroll", inherited, inheritance_hash)
+        if (
+            entry_class == "enterprise-ca"
+            and write_property
+            and not object_type_present
+        ):
+            add_relation(sid, "ManageCA", inherited, inheritance_hash)
+            if access == 0xF00FF:
+                add_relation(sid, "ManageCertificates", inherited, inheritance_hash)
+
+    if entry_class == "gpo":
+        # SharpHound keeps the duplicate edges produced by repeated, identical
+        # non-inherited ACEs on the default GPOs.  Preserve those edges only
+        # when the duplicate is present in the source descriptor; do not turn
+        # the normal relation set into synthetic duplicates.
+        repeated_full_control = {}
+        for ace in dacl.get("ACEs", []):
+            if (
+                ace.get("Raw Type") in (0, 5)
+                and not (ace.get("Raw Flags", 0) & 0x10)
+                and not (ace.get("Raw Flags", 0) & 0x8)
+                and not (ace.get("Raw Object Flags", 0) & 0x1)
+                and not _guid(ace.get("GUID"))
+                and ace.get("Raw Access Required", 0) == 0xE00BD
+                and ace.get("SID") not in _IGNORED_ACL_SIDS
+            ):
+                sid = ace.get("SID")
+                repeated_full_control[sid] = repeated_full_control.get(sid, 0) + 1
+
+        for sid, count in repeated_full_control.items():
+            if count < 2:
+                continue
+            normalized_sid = _normalize_identifier(sid, domain)
+            for right_name in ("GenericWrite", "WriteDacl", "WriteOwner"):
+                relation = next(
+                    (
+                        dict(item)
+                        for item in result
+                        if item["PrincipalSID"] == normalized_sid
+                        and item["RightName"] == right_name
+                        and not item["IsInherited"]
+                    ),
+                    None,
+                )
+                if relation is not None:
+                    result.append(relation)
+    return result
+
+
+def _descriptor_principals(
+    descriptor,
+    right_name,
+    domain,
+    resolve_principal=None,
+):
+    """Return BloodHound relations for principals in a security descriptor."""
+    descriptor = _coerce_descriptor(descriptor)
+    if not isinstance(descriptor, dict):
+        return []
+    result = []
+    seen = set()
+    for ace in descriptor.get("DACL", {}).get("ACEs", []):
+        if ace.get("Raw Type") not in (0, 5):
+            continue
+        flags = ace.get("Raw Flags", 0)
+        if not (flags & 0x10) and flags & 0x8:
+            continue
+        sid = ace.get("SID")
+        if not sid or sid in _IGNORED_ACL_SIDS:
+            continue
+        normalized_sid = _normalize_identifier(sid, domain)
+        key = (normalized_sid, right_name, bool(flags & 0x10))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(
+            {
+                "PrincipalSID": normalized_sid,
+                "PrincipalType": _principal_type(sid, resolve_principal),
+                "RightName": right_name,
+                "IsInherited": bool(flags & 0x10),
+                "InheritanceHash": "",
+                "IsPermissionForOwnerRightsSid": False,
+                "IsInheritedPermissionForOwnerRightsSid": False,
+            }
+        )
+    return result
+
+
+def _rbcd_targets(record, domain, resolve_principal=None):
+    """Convert msDS-AllowedToAct... into BloodHound target references."""
+    descriptor = _coerce_descriptor(
+        _record_value(record, "msDS-AllowedToActOnBehalfOfOtherIdentity")
+    )
+    if not isinstance(descriptor, dict):
+        return []
+    result = []
+    seen = set()
+    for ace in descriptor.get("DACL", {}).get("ACEs", []):
+        if ace.get("Raw Type") not in (0, 5):
+            continue
+        sid = ace.get("SID")
+        if not sid or sid in _IGNORED_ACL_SIDS:
+            continue
+        identifier = _normalize_identifier(sid, domain)
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        result.append(
+            {
+                "ObjectIdentifier": identifier,
+                "ObjectType": _principal_type(sid, resolve_principal),
+            }
+        )
+    return result
+
+
+def _delegation_targets(record, domain, resolve_host=None):
+    """Resolve constrained-delegation SPNs to BloodHound computer objects."""
+    if not resolve_host:
+        return []
+    result = []
+    seen = set()
+    for value in _as_list(record.get("msDS-AllowedToDelegateTo")):
+        if not isinstance(value, str) or "/" not in value:
+            continue
+        hostname = value.split("/", 1)[1].split(":", 1)[0].split("/", 1)[0]
+        if "." not in hostname and domain:
+            hostname = f"{hostname}.{domain}"
+        resolved = resolve_host(hostname)
+        if not isinstance(resolved, dict):
+            continue
+        identifier = _normalize_identifier(_first(resolved.get("objectSid")), domain)
+        if not identifier or identifier in seen:
+            continue
+        seen.add(identifier)
+        result.append({"ObjectIdentifier": identifier, "ObjectType": "Computer"})
+    return result
+
+
+def _synthetic_nodes(data, object_type, domain, domain_sid, include_well_known=False):
+    if object_type not in {"groups", "users"}:
+        return
+    expected_type = "User" if object_type == "users" else "Group"
+    existing = {node.get("ObjectIdentifier") for node in data}
+    referenced = set(_WELL_KNOWN_NAMES) if include_well_known else set()
+    for node in data:
+        for ace in node.get("Aces", []):
+            sid = ace.get("PrincipalSID", "")
+            for known_sid in _WELL_KNOWN_NAMES:
+                if sid == _normalize_identifier(known_sid, domain):
+                    referenced.add(known_sid)
+
+    for sid in sorted(referenced):
+        if _principal_type(sid) != expected_type:
+            continue
+        identifier = _normalize_identifier(sid, domain)
+        if identifier in existing:
+            continue
+        name = f"{_WELL_KNOWN_NAMES[sid]}@{domain}".upper()
+        node_domain_sid = None if sid in _WELL_KNOWN_USER_SIDS else domain_sid
+        node = {
+            "ObjectIdentifier": identifier,
+            "Properties": {
+                "domain": domain.upper(),
+                "domainsid": domain_sid,
+                "name": name,
+                "isaclprotected": False,
+                "reconcile": False,
+            },
+            "Aces": [],
+            "IsDeleted": False,
+            "IsACLProtected": False,
+        }
+        if object_type == "groups":
+            node.update(
+                {"Members": [], "DomainSID": node_domain_sid, "HasSIDHistory": []}
+            )
+        else:
+            node.update(
+                {
+                    "DomainSID": node_domain_sid,
+                    "PrimaryGroupSID": None,
+                    "HasSIDHistory": [],
+                    "AllowedToDelegate": [],
+                    "UnconstrainedDelegation": False,
+                    "SPNTargets": [],
+                    "ContainedBy": None,
+                }
+            )
+        data.append(node)
+
+
+def _add_domain_controller_members(data, domain, domain_controllers):
+    """Populate the synthetic Enterprise Domain Controllers group."""
+    if not domain_controllers:
+        return
+    identifier = _normalize_identifier("S-1-5-9", domain)
+    group = next(
+        (node for node in data if node.get("ObjectIdentifier") == identifier),
+        None,
+    )
+    if not group:
+        return
+    members = group.setdefault("Members", [])
+    existing = {member.get("ObjectIdentifier") for member in members}
+    for computer in domain_controllers:
+        sid = _first(computer.get("objectSid"))
+        if not sid:
+            continue
+        sid = _normalize_identifier(sid, domain)
+        if sid in existing:
+            continue
+        existing.add(sid)
+        members.append({"ObjectIdentifier": sid, "ObjectType": "Computer"})
+
+
+def _security_descriptor(record):
+    return _coerce_descriptor(_record_value(record, "nTSecurityDescriptor"))
+
+
+def _owner_rights_flags(record):
+    descriptor = _security_descriptor(record)
+    if not isinstance(descriptor, dict):
+        return False, False
+    aces = descriptor.get("DACL", {}).get("ACEs", [])
+    owner_rights = [ace for ace in aces if ace.get("SID") == "S-1-3-4"]
+    return bool(owner_rights), any(
+        bool(ace.get("Raw Flags", 0) & 0x10) for ace in owner_rights
+    )
+
+
+def _properties(
+    record,
+    object_type,
+    domain,
+    domain_sid,
+    name,
+    dn,
+    acl_protected,
+    certtemplate_records=None,
+):
+    properties = {
+        "domain": domain.upper(),
+        "domainsid": domain_sid,
+        "distinguishedname": dn.upper() if isinstance(dn, str) else dn,
+        "name": name,
+    }
+
+    for key, value in record.items():
+        property_name = str(key).lower()
+        if property_name in _SKIPPED_PROPERTIES:
+            continue
+        if isinstance(value, (date, datetime)) or property_name in {
+            "accountexpires",
+            "badpasswordtime",
+            "lastlogon",
+            "lastlogoff",
+            "lastlogontimestamp",
+            "lockouttime",
+            "pwdlastset",
+            "whencreated",
+            "whenchanged",
+        }:
+            value = _as_timestamp(value)
+        properties[property_name] = value
+
+    object_guid = _first(record.get("objectGUID"))
+    if object_guid:
+        properties["objectguid"] = _normalize_identifier(object_guid, domain)
+    if "description" in record:
+        properties["description"] = _first(record.get("description"))
+    if "displayName" in record:
+        properties["displayname"] = _first(record.get("displayName"))
+    aliases = {
+        "displayname": ("displayName",),
+        "email": ("mail", "email"),
+        "homedirectory": ("homeDirectory",),
+        "logonscript": ("scriptPath",),
+        "profilepath": ("profilePath",),
+        "sfupassword": ("msSFU30Password",),
+        "title": ("title",),
+        "unicodepassword": ("unicodePwd",),
+        "unixpassword": ("unixUserPassword",),
+        "userpassword": ("userPassword",),
+    }
+    for target, source_names in aliases.items():
+        value = _record_value(record, *source_names)
+        if value is not None:
+            properties[target] = _first(value)
+    properties["isaclprotected"] = acl_protected
+    owner_rights, inherited_owner_rights = _owner_rights_flags(record)
+    properties["doesanyacegrantownerrights"] = owner_rights
+    properties["doesanyinheritedacegrantownerrights"] = inherited_owner_rights
+
+    uac = _record_value(record, "userAccountControl")
+    if uac is not None:
+        properties["useraccountcontrol"] = _uac_value(uac)
+    if object_type in {"users", "computers"}:
+        admin_count = record.get("adminCount")
+        properties.update(
+            {
+                "enabled": not _uac_contains(uac, "ACCOUNTDISABLE"),
+                "hasspn": bool(record.get("servicePrincipalName")),
+                "samaccountname": _first(record.get("sAMAccountName"), ""),
+                "serviceprincipalnames": _as_list(record.get("servicePrincipalName")),
+                "trustedtoauth": _uac_contains(uac, "TRUSTED_TO_AUTH_FOR_DELEGATION"),
+                "unconstraineddelegation": _uac_contains(uac, "TRUSTED_FOR_DELEGATION"),
+                "whencreated": _as_timestamp(record.get("whenCreated")),
+                "supportedencryptiontypes": _encryption_types(
+                    record.get("msDS-SupportedEncryptionTypes")
+                ),
+                "adminsdholderprotected": (
+                    bool(_first(admin_count)) if admin_count is not None else False
+                ),
+                "encryptedtextpwdallowed": _uac_contains(
+                    uac, "ENCRYPTED_TEXT_PWD_ALLOWED"
+                ),
+                "lockedout": _uac_contains(uac, "LOCKOUT"),
+                "logonscriptenabled": bool(record.get("scriptPath")),
+                "passwordexpired": _uac_contains(uac, "PASSWORD_EXPIRED"),
+                "sidhistory": _as_list(record.get("sIDHistory")),
+                "smartcardrequired": _uac_contains(uac, "SMARTCARD_REQUIRED"),
+                "usedeskeyonly": _uac_contains(uac, "USE_DES_KEY_ONLY"),
+            }
+        )
+        if object_type == "computers":
+            properties.setdefault("email", None)
+    if object_type == "users":
+        for field in (
+            "displayname",
+            "email",
+            "homedirectory",
+            "logonscript",
+            "passwordcantchange",
+            "profilepath",
+            "sfupassword",
+            "title",
+            "unicodepassword",
+            "unixpassword",
+            "userpassword",
+        ):
+            properties.setdefault(field, None)
+        properties.update(
+            {
+                "admincount": bool(_first(record.get("adminCount"), 0)),
+                "dontreqpreauth": _uac_contains(uac, "DONT_REQ_PREAUTH"),
+                "passwordnotreqd": _uac_contains(uac, "PASSWD_NOTREQD"),
+                "passwordcantchange": _uac_contains(uac, "PASSWD_CANT_CHANGE"),
+                "pwdneverexpires": _uac_contains(uac, "DONT_EXPIRE_PASSWORD"),
+                "sensitive": _uac_contains(uac, "NOT_DELEGATED"),
+                "encryptedtextpwdallowed": _uac_contains(
+                    uac, "ENCRYPTED_TEXT_PWD_ALLOWED"
+                ),
+                "passwordexpired": _uac_contains(uac, "PASSWORD_EXPIRED"),
+                "smartcardrequired": _uac_contains(uac, "SMARTCARD_REQUIRED"),
+                "usedeskeyonly": _uac_contains(uac, "USE_DES_KEY_ONLY"),
+                "reconcile": False,
+                "gmsa": "msds-groupmanagedserviceaccount"
+                in {
+                    str(value).lower()
+                    for value in _as_list(_record_value(record, "objectClass"))
+                },
+            }
+        )
+        allowed_to_delegate = _record_value(record, "msDS-AllowedToDelegateTo")
+        if allowed_to_delegate is not None:
+            properties["allowedtodelegate"] = _as_list(allowed_to_delegate)
+    if object_type == "computers":
+        properties["admincount"] = bool(_first(record.get("adminCount"), 0))
+        properties["isdc"] = _first(record.get("primaryGroupID")) == 516
+        properties["isreadonlydc"] = False
+        properties["supportedencryptiontypes"] = _encryption_types(
+            record.get("msDS-SupportedEncryptionTypes")
+        )
+        properties["haslaps"] = any(
+            _record_value(record, attribute) is not None
+            for attribute in (
+                "ms-Mcs-AdmPwd",
+                "ms-Mcs-AdmPwdExpirationTime",
+                "msLAPS-Password",
+                "msLAPS-PasswordExpirationTime",
+                "msLAPS-EncryptedPassword",
+                "msLAPS-EncryptedPasswordExpirationTime",
+            )
+        )
+    if object_type == "groups":
+        admin_count = record.get("adminCount")
+        group_type = str(_first(record.get("groupType"), ""))
+        properties["groupscope"] = next(
+            (
+                scope
+                for scope in ("Global", "Universal", "DomainLocal")
+                if scope.upper().replace("LOCAL", "_LOCAL") in group_type.upper()
+            ),
+            "",
+        )
+        properties.update(
+            {
+                "admincount": bool(_first(record.get("adminCount"), 0)),
+                "samaccountname": _first(record.get("sAMAccountName"), ""),
+                "adminsdholderprotected": (
+                    bool(_first(admin_count)) if admin_count is not None else False
+                ),
+                "sidhistory": _as_list(record.get("sIDHistory")),
+                "reconcile": False,
+            }
+        )
+    if object_type == "domains":
+        behavior = _first(record.get("msDS-Behavior-Version"))
+        properties["functionallevel"] = {
+            0: "2000",
+            1: "2003",
+            2: "2003",
+            3: "2008",
+            4: "2008 R2",
+            5: "2012",
+            6: "2012 R2",
+            7: "2016",
+            10: "2025",
+        }.get(behavior, behavior)
+        properties["machineaccountquota"] = _first(
+            record.get("ms-DS-MachineAccountQuota")
+        )
+        properties["collected"] = True
+        properties["netbios"] = str(
+            _first(record.get("dc"), domain.split(".", 1)[0])
+        ).upper()
+        properties["dsheuristics"] = _first(record.get("dSHeuristics"))
+        properties["expirepasswordsonsmartcardonlyaccounts"] = bool(
+            _first(
+                record.get("msDS-ExpirePasswordsOnSmartCardOnlyAccounts"),
+                record.get("ms-DS-ExpirePasswordsOnSmartCardOnlyAccounts"),
+            )
+        )
+        properties["maxpwdage"] = _ad_duration(record.get("maxPwdAge"), forever=True)
+        properties["minpwdage"] = _ad_duration(record.get("minPwdAge"))
+        properties["lockoutduration"] = _ad_duration(record.get("lockoutDuration"))
+        properties["lockoutobservationwindow"] = _first(
+            record.get("lockOutObservationWindow"),
+            record.get("lockoutDuration"),
+        )
+        properties["pwdproperties"] = _password_properties(record.get("pwdProperties"))
+    if object_type == "gpos":
+        gpc_path = _first(record.get("gPCFileSysPath"))
+        properties["gpcpath"] = (
+            gpc_path.upper() if isinstance(gpc_path, str) else gpc_path
+        )
+        properties["gpostatus"] = str(_first(record.get("flags"), "0"))
+    if object_type == "ous":
+        properties["blocksinheritance"] = _first(record.get("gPOptions"), 0) == 1
+    if object_type == "enterprisecas":
+        descriptor = _security_descriptor(record)
+        properties.update(
+            {
+                "caname": _first(record.get("cn"), _first(record.get("name"), "")),
+                "dnshostname": _first(record.get("dNSHostName")),
+                "flags": _ca_flags(record.get("flags")),
+                # ldeep collects the published template names, but not the
+                # template objects/GUIDs required for EnabledCertTemplates.
+                "unresolvedpublishedtemplates": _unresolved_published_templates(
+                    record, certtemplate_records
+                ),
+                "casecuritycollected": isinstance(descriptor, dict),
+                "enrollmentagentrestrictionscollected": False,
+                "isuserspecifiessanenabledcollected": False,
+                "roleseparationenabledcollected": False,
+            }
+        )
+        properties.update(_certificate_properties(record))
+    if object_type == "certtemplates":
+        properties.update(_certificate_template_properties(record))
+    if object_type == "issuancepolicies":
+        properties["certtemplateoid"] = _record_first(record, "msPKI-Cert-Template-OID")
+    if object_type in {"rootcas", "aiacas", "ntauthstores"}:
+        properties.update(_certificate_properties(record))
+        cross_certificate_pair = _record_value(record, "crossCertificatePair")
+        if object_type == "aiacas":
+            properties["crosscertificatepair"] = _as_list(cross_certificate_pair)
+            properties["hascrosscertificatepair"] = bool(cross_certificate_pair)
+        if object_type == "ntauthstores":
+            properties.setdefault("certthumbprints", [])
+    return properties
+
+
+def _member_type(record):
+    classes = {str(value).lower() for value in _as_list(record.get("objectClass"))}
+    # BloodHound represents a gMSA as a User node even though AD also puts
+    # the computer class on the object.  Check this before ``computer`` so
+    # group membership edges use the same type as SharpHound.
+    if "msds-groupmanagedserviceaccount" in classes:
+        return "User"
+    if "computer" in classes:
+        return "Computer"
+    if "group" in classes:
+        return "Group"
+    if (
+        "user" in classes
+        or "person" in classes
+        or "msds-groupmanagedserviceaccount" in classes
+        or "msds-managedserviceaccount" in classes
+    ):
+        return "User"
+    if "foreignsecurityprincipal" in classes:
+        return _principal_type(_first(record.get("objectSid")))
+    return "Unknown"
+
+
+def _convert_record(
+    record,
+    object_type,
+    resolve_member=None,
+    resolve_principal=None,
+    resolve_host=None,
+    domain_sid="",
+    object_type_guids=None,
+    certtemplate_records=None,
+    gpo_records=None,
+    configuration_records=None,
+    containment_records=None,
+    computer_records=None,
+):
+    dn = record.get("distinguishedName") or record.get("dn") or ""
+    domain = _domain_from_dn(dn)
+    sid = _first(record.get("objectSid"), "")
+    domain_sid = _domain_sid(sid) or domain_sid
+    if object_type in {
+        "containers",
+        "certtemplates",
+        "rootcas",
+        "aiacas",
+        "ntauthstores",
+        "issuancepolicies",
+    }:
+        identifier = _configuration_identifier(record, object_type)
+    else:
+        identifier = _normalize_identifier(
+            sid or _first(record.get("objectGUID")) or dn, domain
+        )
+    descriptor = _security_descriptor(record)
+    acl_protected = (
+        bool((_first((descriptor or {}).get("Raw Type"), 0)) & 0x1000)
+        if isinstance(descriptor, dict)
+        else False
+    )
+    name = _object_name(record, object_type, domain)
+    converted = {
+        "ObjectIdentifier": identifier,
+        "Properties": _properties(
+            record,
+            object_type,
+            domain,
+            domain_sid,
+            name,
+            dn,
+            acl_protected,
+            certtemplate_records=certtemplate_records,
+        ),
+        "Aces": _aces(
+            record,
+            object_type,
+            domain,
+            resolve_principal,
+            object_type_guids,
+        ),
+        "IsDeleted": bool(_first(record.get("isDeleted"), False)),
+        "IsACLProtected": acl_protected,
+    }
+
+    if object_type in {"users", "computers"}:
+        converted["DomainSID"] = domain_sid
+        if object_type == "users" and (
+            sid in _WELL_KNOWN_USER_SIDS or str(sid).endswith("-S-1-5-17")
+        ):
+            # IUSR is a well-known principal, not a domain account.  Keep
+            # the domain context in Properties, but do not attach a domain
+            # SID to the node itself.
+            converted["DomainSID"] = None
+        converted["UnconstrainedDelegation"] = _uac_contains(
+            record.get("userAccountControl"), "TRUSTED_FOR_DELEGATION"
+        )
+        converted["PrimaryGroupSID"] = None
+        primary_group = _first(record.get("primaryGroupID"))
+        if primary_group and domain_sid:
+            converted["PrimaryGroupSID"] = f"{domain_sid}-{primary_group}"
+        converted["AllowedToDelegate"] = _as_list(
+            _delegation_targets(record, domain, resolve_host)
+        )
+        converted["HasSIDHistory"] = _as_list(record.get("sIDHistory"))
+    if object_type == "users":
+        converted["SPNTargets"] = []
+        converted["Aces"].extend(
+            _descriptor_principals(
+                record.get("msDS-GroupMSAMembership"),
+                "ReadGMSAPassword",
+                domain,
+                resolve_principal,
+            )
+        )
+    elif object_type == "computers":
+        converted["IsDC"] = _first(record.get("primaryGroupID")) == 516
+        converted["AllowedToAct"] = _rbcd_targets(
+            record,
+            domain,
+            resolve_principal,
+        )
+        # BloodHound models computer sessions as a collection result,
+        # rather than as a bare list.  Keep it explicitly uncollected since
+        # ldeep's LDAP/cache computer query does not perform session
+        # enumeration.
+        converted["Sessions"] = {
+            "Results": [],
+            "Collected": False,
+            "FailureReason": None,
+        }
+        converted["DcomUsers"] = {
+            "Results": [],
+            "Collected": False,
+            "FailureReason": None,
+        }
+        converted["LocalAdmins"] = {
+            "Results": [],
+            "Collected": False,
+            "FailureReason": None,
+        }
+        converted["PSRemoteUsers"] = {
+            "Results": [],
+            "Collected": False,
+            "FailureReason": None,
+        }
+        converted["RemoteDesktopUsers"] = {
+            "Results": [],
+            "Collected": False,
+            "FailureReason": None,
+        }
+    elif object_type == "groups":
+        members = []
+        for member in _as_list(record.get("member")):
+            resolved = resolve_member(member) if resolve_member else None
+            if not isinstance(resolved, dict):
+                continue
+            member_identifier = _normalize_identifier(
+                _first(resolved.get("objectSid")), domain
+            )
+            if not member_identifier:
+                continue
+            members.append(
+                {
+                    "ObjectIdentifier": member_identifier,
+                    "ObjectType": _member_type(resolved),
+                }
+            )
+        converted["Members"] = members
+        converted["DomainSID"] = domain_sid
+        converted["HasSIDHistory"] = _as_list(record.get("sIDHistory"))
+    elif object_type == "issuancepolicies":
+        converted["GroupLink"] = {
+            "ObjectIdentifier": None,
+            "ObjectType": "Base",
+        }
+    if object_type in {"domains", "ous", "users", "computers"}:
+        converted.update(
+            {
+                "ChildObjects": [],
+                "Links": _gpo_links(record, gpo_records),
+                "GPOChanges": {
+                    "AffectedComputers": _affected_computers(
+                        record, object_type, computer_records
+                    ),
+                    "DcomUsers": [],
+                    "LocalAdmins": [],
+                    "PSRemoteUsers": [],
+                    "RemoteDesktopUsers": [],
+                },
+            }
+        )
+        if object_type in {"ous", "users", "computers"}:
+            contained_by = _core_parent(record, containment_records, domain_sid)
+            if contained_by:
+                converted["ContainedBy"] = contained_by
+    if object_type in {"groups", "gpos"}:
+        contained_by = _core_parent(record, containment_records, domain_sid)
+        if contained_by:
+            converted["ContainedBy"] = contained_by
+    if object_type == "containers":
+        converted["ChildObjects"] = []
+        converted["InheritanceHashes"] = _inheritance_hashes(record)
+    elif object_type in {"domains", "ous"}:
+        converted["InheritanceHashes"] = _inheritance_hashes(record)
+    if object_type == "domains":
+        converted["ContainedBy"] = None
+        converted["ForestRootIdentifier"] = identifier
+        converted["Trusts"] = []
+    elif object_type in {"rootcas", "ntauthstores"}:
+        converted["DomainSID"] = domain_sid
+    elif object_type == "enterprisecas":
+        hosting_computer = None
+        hostname = _first(record.get("dNSHostName"))
+        if resolve_host and hostname:
+            resolved = resolve_host(hostname)
+            if isinstance(resolved, dict):
+                hosting_computer = _normalize_identifier(
+                    _first(resolved.get("objectSid")), domain
+                )
+        converted.update(
+            {
+                "HostingComputer": hosting_computer,
+                "EnabledCertTemplates": [
+                    {
+                        "ObjectIdentifier": entry["identifier"],
+                        "ObjectType": "CertTemplate",
+                    }
+                    for entry in _published_template_entries(
+                        record, certtemplate_records
+                    )
+                ],
+                "HttpEnrollmentEndpoints": [],
+                "CARegistryData": {},
+            }
+        )
+        contained_by = _configuration_parent(record, configuration_records, domain_sid)
+        if contained_by:
+            converted["ContainedBy"] = contained_by
+    return converted
+
+
+def _trust_int(value, names):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value, 0)
+        except ValueError:
+            return sum(bit for bit, name in names.items() if name in value)
+    return 0
+
+
+def _convert_trusts(records):
+    directions = {
+        0: "Disabled",
+        1: "Inbound",
+        2: "Outbound",
+        3: "Bidirectional",
+    }
+    types = {
+        1: "External",
+        2: "Forest",
+        3: "External",
+    }
+    attributes = {
+        0x1: "NON_TRANSITIVE",
+        0x2: "UPLEVEL_ONLY",
+        0x4: "QUARANTINED_DOMAIN",
+        0x8: "FOREST_TRANSITIVE",
+        0x10: "CROSS_ORGANIZATION",
+        0x20: "WITHIN_FOREST",
+        0x40: "TREAT_AS_EXTERNAL",
+        0x80: "USES_RC4_ENCRYPTION",
+        0x100: "USES_AES_KEYS",
+        0x200: "CROSS_ORGANIZATION_NO_TGT_DELEGATION",
+        0x400: "PIM_TRUST",
+        0x800: "CROSS_ORGANIZATION_ENABLE_TGT_DELEGATION",
+    }
+    converted = []
+    for record in records or []:
+        target_sid = _first(record.get("securityIdentifier"))
+        target_name = _first(record.get("trustPartner"), _first(record.get("name"), ""))
+        if not target_sid or not target_name:
+            continue
+        trust_attributes = _trust_int(record.get("trustAttributes"), attributes)
+        trust_type = _first(record.get("trustType"), 0)
+        try:
+            trust_type = int(trust_type)
+        except (TypeError, ValueError):
+            trust_type = 0
+        converted.append(
+            {
+                "TargetDomainSid": str(target_sid).upper(),
+                "TargetDomainName": str(target_name).upper(),
+                "IsTransitive": not bool(trust_attributes & 0x1),
+                "SidFilteringEnabled": bool(trust_attributes & 0x4) or trust_type == 2,
+                "TGTDelegationEnabled": bool(trust_attributes & 0x800),
+                "TrustAttributes": trust_attributes,
+                "TrustDirection": directions.get(
+                    _first(record.get("trustDirection"), 0), "Disabled"
+                ),
+                "TrustType": types.get(trust_type, "External"),
+            }
+        )
+    return converted
+
+
+def convert(
+    records,
+    resolve_member=None,
+    resolve_principal=None,
+    resolve_host=None,
+    domain_sid="",
+    trusts=None,
+    include_well_known=False,
+    object_type_hint=None,
+    object_type_guids=None,
+    domain_controllers=None,
+    certtemplate_records=None,
+    gpo_records=None,
+    configuration_records=None,
+    containment_records=None,
+    computer_records=None,
+):
+    """Convert records into one BloodHound v6 JSON document."""
+    records = list(records)
+    source_records = records
+    if not records:
+        object_type = object_type_hint or "users"
+    else:
+        if any(not isinstance(record, dict) for record in records):
+            raise ValueError("BloodHound output requires ldeep record objects")
+        object_types = {_object_type(record) for record in records}
+        if None in object_types:
+            raise ValueError(
+                "BloodHound output cannot classify one or more ldeep records"
+            )
+        # ldeep's OU query also returns the domain naming context.  The
+        # domain is emitted by domain_policy, so omit that extra record from
+        # the OU document instead of producing a mixed BloodHound file.
+        if object_types == {"domains", "ous"}:
+            records = [record for record in records if _object_type(record) == "ous"]
+            object_types = {"ous"}
+        if len(object_types) != 1:
+            raise ValueError(
+                "BloodHound output requires records of one object type; "
+                f"got {', '.join(sorted(object_types))}"
+            )
+        object_type = object_types.pop()
+
+    data = [
+        _convert_record(
+            record,
+            object_type,
+            resolve_member=resolve_member,
+            resolve_principal=resolve_principal,
+            resolve_host=resolve_host,
+            domain_sid=domain_sid,
+            object_type_guids=object_type_guids,
+            certtemplate_records=certtemplate_records,
+            gpo_records=gpo_records,
+            configuration_records=configuration_records,
+            containment_records=containment_records or source_records,
+            computer_records=computer_records,
+        )
+        for record in records
+    ]
+    if object_type == "domains" and data:
+        data[0]["Trusts"] = _convert_trusts(trusts)
+    record_domain = ""
+    if records:
+        record_domain = _domain_from_dn(
+            records[0].get("distinguishedName") or records[0].get("dn") or ""
+        )
+    _synthetic_nodes(
+        data,
+        object_type,
+        record_domain,
+        domain_sid,
+        include_well_known=include_well_known,
+    )
+    if object_type == "groups":
+        _add_domain_controller_members(data, record_domain, domain_controllers)
+    meta = {
+        "collectorversion": f"ldeep {__version__}",
+        "methods": BLOODHOUND_METHODS,
+        "type": object_type,
+        "count": len(data),
+        "version": BLOODHOUND_VERSION,
+    }
+    if object_type == "enterprisecas":
+        # ADCS node files use the v6 schema in BloodHound Community Edition.
+        meta.update({"methods": 15725567, "version": 6})
+    return {
+        "data": data,
+        "meta": meta,
+    }
+
+
+def _configuration_document(
+    records,
+    object_type,
+    domain_sid="",
+    certificate_records=None,
+    principal_records=None,
+):
+    """Build one BloodHound document for a Configuration object type."""
+    data = []
+    seen = set()
+    for record in records or []:
+        if not isinstance(record, dict):
+            continue
+        identifier = _configuration_identifier(record, object_type)
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        node = _convert_record(
+            record,
+            object_type,
+            domain_sid=domain_sid,
+            resolve_principal=(
+                lambda sid: (
+                    next(
+                        (
+                            candidate
+                            for candidate in principal_records or []
+                            if _first(candidate.get("objectSid")) == sid
+                        ),
+                        None,
+                    )
+                    if principal_records is not None
+                    else None
+                )
+            ),
+        )
+        if object_type in {"rootcas", "aiacas"} and not any(
+            key in node["Properties"] for key in ("certthumbprint", "certchain")
+        ):
+            record_name = _record_first(record, "cn", "name")
+            for ca_record in certificate_records or []:
+                ca_name = _record_first(ca_record, "cn", "name")
+                if (
+                    record_name
+                    and ca_name
+                    and str(record_name).casefold() == str(ca_name).casefold()
+                ):
+                    node["Properties"].update(_certificate_properties(ca_record))
+                    break
+        if object_type == "ntauthstores":
+            fingerprints = []
+            for ca_record in certificate_records or []:
+                fingerprint = _certificate_properties(ca_record).get("certthumbprint")
+                if fingerprint and fingerprint not in fingerprints:
+                    fingerprints.append(fingerprint)
+            if fingerprints:
+                node["Properties"]["certthumbprints"] = fingerprints
+        if not _first(record.get("objectGUID")):
+            node["Properties"]["synthetic"] = True
+            node["Properties"]["unresolvedsource"] = "ldeep conf distinguishedName"
+        data.append(node)
+
+    return {
+        "data": data,
+        "meta": {
+            "collectorversion": f"ldeep {__version__}",
+            "methods": 15725567,
+            "type": object_type,
+            "count": len(data),
+            "version": 6,
+        },
+    }
+
+
+def convert_certtemplates(
+    records, domain_sid="", configuration_records=None, principal_records=None
+):
+    """Convert full certificate-template records when ``conf`` is available.
+
+    Older ldeep dumps only contain the template names published by a CA.  In
+    that case retain the deterministic synthetic fallback so EnterpriseCA
+    references remain importable.  A Configuration dump upgrades those nodes
+    to their real objectGUID, LDAP properties, and ACLs automatically.
+    """
+    template_records = [
+        record
+        for record in configuration_records or []
+        if configuration_object_type(record) == "certtemplates"
+    ]
+    if template_records:
+        return _configuration_document(
+            template_records,
+            "certtemplates",
+            domain_sid=domain_sid,
+            principal_records=principal_records,
+        )
+
+    entries = {}
+    for record in records or []:
+        if not isinstance(record, dict):
+            continue
+        for entry in _published_template_entries(record):
+            entries.setdefault(entry["identifier"], entry)
+
+    data = []
+    for identifier in sorted(entries):
+        entry = entries[identifier]
+        domain = entry["domain"].upper()
+        data.append(
+            {
+                "Properties": {
+                    "domain": domain,
+                    "domainsid": domain_sid,
+                    "name": f"{entry['name']}@{domain}".upper(),
+                    "displayname": entry["name"],
+                    "distinguishedname": entry["dn"].upper(),
+                    "objectguid": identifier,
+                    "isaclprotected": False,
+                    "synthetic": True,
+                    "unresolvedsource": "ldeep certificateTemplates",
+                },
+                "Aces": [],
+                "ObjectIdentifier": identifier,
+                "IsDeleted": False,
+                "IsACLProtected": False,
+            }
+        )
+
+    return {
+        "data": data,
+        "meta": {
+            "collectorversion": f"ldeep {__version__}",
+            "methods": 15725567,
+            "type": "certtemplates",
+            "count": len(data),
+            "version": 6,
+        },
+    }
+
+
+def convert_configuration(
+    records,
+    domain_sid="",
+    certificate_records=None,
+    principal_records=None,
+):
+    """Convert all BloodHound-relevant records from ldeep's ``conf`` dump.
+
+    The function never invents parent objects.  ``ContainedBy`` is added only
+    when the parent DN is itself present in the dump, which keeps partial
+    caches safe while still preserving the complete hierarchy in full dumps.
+    """
+    grouped = {}
+    identifiers_by_dn = {}
+    for record in records or []:
+        if not isinstance(record, dict):
+            continue
+        object_type = configuration_object_type(record)
+        dn = str(record.get("distinguishedName") or record.get("dn") or "")
+        identifier = _configuration_identifier(record, object_type)
+        if dn and _first(record.get("objectGUID")):
+            # Some parents (CN=Configuration and CN=Optional Features, for
+            # example) are useful ContainedBy targets without being emitted
+            # as BloodHound nodes. Index records already present in conf so
+            # the converter can reference them without inventing objects.
+            classes = {
+                str(value).casefold() for value in _as_list(record.get("objectClass"))
+            }
+            first_rdn = dn.casefold().split(",", 1)[0]
+            if "configuration" in classes:
+                parent_type = "configuration"
+            elif first_rdn == "cn=oid":
+                parent_type = "base"
+            else:
+                parent_type = object_type or "base"
+            identifiers_by_dn[dn.casefold()] = (identifier, parent_type)
+        if object_type is None:
+            continue
+        if object_type == "enterprisecas":
+            continue
+        if dn:
+            identifiers_by_dn[dn.casefold()] = (
+                identifier,
+                (
+                    "configuration"
+                    if "configuration" in classes
+                    else "base" if first_rdn == "cn=oid" else object_type
+                ),
+            )
+        grouped.setdefault(object_type, []).append(record)
+
+    documents = {}
+    for object_type, object_records in grouped.items():
+        documents[object_type] = _configuration_document(
+            object_records,
+            object_type,
+            domain_sid=domain_sid,
+            certificate_records=certificate_records,
+            principal_records=principal_records,
+        )
+
+    for object_type, document in documents.items():
+        records_by_identifier = {
+            _configuration_identifier(record, object_type): record
+            for record in grouped[object_type]
+        }
+        for node in document["data"]:
+            record = records_by_identifier.get(node.get("ObjectIdentifier"))
+            if not record:
+                continue
+            dn = str(record.get("distinguishedName") or record.get("dn") or "")
+            parent_dn = dn.split(",", 1)[1] if "," in dn else ""
+            parent = identifiers_by_dn.get(parent_dn.casefold())
+            if parent:
+                node["ContainedBy"] = {
+                    "ObjectIdentifier": parent[0],
+                    "ObjectType": _BH_OBJECT_TYPES.get(parent[1], parent[1]),
+                }
+            elif parent_dn and all(
+                component.strip().casefold().startswith("dc=")
+                for component in parent_dn.split(",")
+            ):
+                node["ContainedBy"] = {
+                    "ObjectIdentifier": domain_sid,
+                    "ObjectType": "Domain",
+                }
+
+    return documents

--- a/ldeep/utils/protections.py
+++ b/ldeep/utils/protections.py
@@ -4,9 +4,12 @@
 A module used to verify LDAP Signing and LDAPS Channel Binding from Active Directory LDAP.
 """
 
-import sys, socket, ssl
+import socket
+import ssl
+import sys
 from io import StringIO
-from ldap3 import Connection, SASL, KERBEROS, NTLM, Server, ALL
+
+from ldap3 import ALL, KERBEROS, NTLM, SASL, Connection, Server
 
 
 # Check LDAP Signing enforcement
@@ -109,9 +112,7 @@ def checkEPA(server, userDN, password, kerberosAuth):
     err = conn.result["message"]
     if "data 80090346" in err:
         return True
-    elif "data 52e" in err:
-        return False
-    elif "LdapErr" not in err:
+    elif "data 52e" in err or "LdapErr" not in err:
         return False
 
 
@@ -124,8 +125,8 @@ def do_ntlm_bind_null_avpair_epa(
         if not self.sasl_in_progress:
             self.sasl_in_progress = True
             try:
-                from ldap3.utils.ntlm import NtlmClient
                 from ldap3.core.connection import bind_operation
+                from ldap3.utils.ntlm import NtlmClient
 
                 domain_name, user_name = self.user.split("\\", 1)
                 self.ntlm_client = NtlmClient(
@@ -159,7 +160,7 @@ def do_ntlm_bind_null_avpair_epa(
                     digest.update(self.server.tls.peer_certificate)
                     peer_certificate_digest = digest.finalize()
 
-                    channel_binding_struct = bytes()
+                    channel_binding_struct = b""
                     initiator_address = b"\x00" * 8
                     acceptor_address = b"\x00" * 8
                     application_data_raw = (
@@ -243,7 +244,7 @@ def checkEPAPolicy(server, userDN, password):
             channel_binding="TLS_CHANNEL_BINDING",
             auto_bind=False,
         )
-    except Exception as e:
+    except Exception:
         return None
     originalSTDOUT = sys.stdout
     originalSTDERR = sys.stderr
@@ -255,9 +256,7 @@ def checkEPAPolicy(server, userDN, password):
     err = conn.result["message"]
     if "data 80090346" in err:
         return True
-    elif "data 52e" in err:
-        return False
-    elif "LdapErr" not in err:
+    elif "data 52e" in err or "LdapErr" not in err:
         return False
 
 
@@ -282,14 +281,14 @@ def checkProtections(target, username, password, ntlm, domain, kerberosAuth):
         print("LDAP Signing not required")
 
     if not LDAPSCompleteHandshake(target):
-        print(f"LDAPS connection failed. DC certificate probably not configured")
+        print("LDAPS connection failed. DC certificate probably not configured")
     else:
         policyEPA = None
         ldapsChannelBindingAlways = checkEPA(
             serverLDAPS, user_dn, password, kerberosAuth
         )
         if ldapsChannelBindingAlways == None:
-            print(f"Failed to verify Channel Binding (EPA) enforcement")
+            print("Failed to verify Channel Binding (EPA) enforcement")
         else:
             if ldapsChannelBindingAlways == True:
                 policyEPA = "Always"
@@ -303,7 +302,7 @@ def checkProtections(target, username, password, ntlm, domain, kerberosAuth):
                         serverLDAPS, user_dn, password
                     )
                     if ldapsChannelBindingWhenSupported == None:
-                        print(f"Failed to verify Channel Binding (EPA) policy")
+                        print("Failed to verify Channel Binding (EPA) policy")
                     else:
                         if ldapsChannelBindingWhenSupported == True:
                             policyEPA = "When supported"

--- a/ldeep/views/activedirectory.py
+++ b/ldeep/views/activedirectory.py
@@ -8,7 +8,7 @@ validate_sid = validate_sid
 validate_guid = validate_guid
 
 
-class ActiveDirectoryView(object):
+class ActiveDirectoryView:
     """
     Manage a view of a Active Directory.
     """

--- a/ldeep/views/cache_activedirectory.py
+++ b/ldeep/views/cache_activedirectory.py
@@ -59,20 +59,36 @@ def eq_anr(record, value):
 
 
 class CacheActiveDirectoryView(ActiveDirectoryView):
+    USER_CACHE_FILES = (
+        "users_all",
+        "users_enabled",
+        "users_disabled",
+        "users_locked",
+        "users_nopasswordexpire",
+        "users_passwordexpired",
+        "users_passwordnotrequired",
+        "users_nokrbpreauth",
+        "users_reversible",
+        "users_spn",
+    )
+    DELEGATION_CACHE_FILES = (
+        "delegations_all",
+        "delegations_unconstrained",
+        "delegations_constrained",
+        "delegations_rbcd",
+    )
+
     # Constant functions (first arg -> self but we don't need it)
     GROUPS_FILTER = lambda _: {"files": ["groups"]}
-    USER_ALL_FILTER = lambda _: {"files": ["users_all"]}
     USER_SPN_FILTER = lambda _: {
         "files": ["users_spn"],
         "replacement": {
             "files": ["users_all"],
-            "filter": lambda x: x.get("servicePrincipalName", None) is not None
-            and x["sAMAccountName"] != "krbtgt",
+            "filter": lambda x: (
+                x.get("servicePrincipalName", None) is not None
+                and x["sAMAccountName"] != "krbtgt"
+            ),
         },
-    }
-    COMPUTERS_FILTER = lambda _, n: {
-        "files": ["machines"],
-        "filter": lambda x: True if n == "*" else eq(x["cn"], n),
     }
     DC_FILTER = lambda _: {
         "files": ["machines"],
@@ -90,8 +106,10 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
     ACCOUNTS_IN_GROUP_FILTER = lambda _, p, g: {
         "fmt": "json",
         "files": ["users_all", "smsa", "gmsa", "groups", "machines"],
-        "filter": lambda x: ("primaryGroupID" in x and eq(p, x["primaryGroupID"]))
-        or ("memberOf" in x and g in x["memberOf"]),
+        "filter": lambda x: (
+            ("primaryGroupID" in x and eq(p, x["primaryGroupID"]))
+            or ("memberOf" in x and g in x["memberOf"])
+        ),
     }
     ACCOUNT_IN_GROUPS_FILTER = lambda _, u: {
         "fmt": "json",
@@ -100,7 +118,13 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
     }
     DISTINGUISHED_NAME = lambda _, n: {
         "fmt": "json",
-        "files": ["users_all", "groups", "machines", "shadow_principals"],
+        "files": [
+            "users_all",
+            "gmsa",
+            "groups",
+            "machines",
+            "shadow_principals",
+        ],
         "filter": lambda x: eq(x["distinguishedName"], n),
     }
     PRIMARY_GROUP_ID = lambda _, i: {
@@ -132,6 +156,7 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         "filter": lambda x: True if n == "*" else eq(x["distinguishedName"], n),
     }
     PKI_FILTER = lambda _: {"files": ["pkis"]}
+    ALL_FILTER = lambda _: {"files": ["conf"]}
     BITLOCKERKEY_FILTER = lambda _: {"files": ["bitlockerkeys"]}
     FSP_FILTER = lambda _, n: {
         "files": ["fsp"],
@@ -141,9 +166,11 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         "files": ["delegations_all"],
         "replacement": {
             "files": ["users_all", "machines"],
-            "filter": lambda x: "TRUSTED_FOR_DELEGATION" in x["userAccountControl"]
-            or x.get("msDS-AllowedToDelegateTo", None) is not None
-            or x.get("msDS-AllowedToActOnBehalfOfOtherIdentity") is not None,
+            "filter": lambda x: (
+                "TRUSTED_FOR_DELEGATION" in x["userAccountControl"]
+                or x.get("msDS-AllowedToDelegateTo", None) is not None
+                or x.get("msDS-AllowedToActOnBehalfOfOtherIdentity") is not None
+            ),
         },
     }
     UNCONSTRAINED_DELEGATION_FILTER = lambda _: {
@@ -164,8 +191,9 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         "files": ["delegations_rbcd"],
         "replacement": {
             "files": ["users_all", "machines"],
-            "filter": lambda x: x.get("msDS-AllowedToActOnBehalfOfOtherIdentity", None)
-            is not None,
+            "filter": lambda x: (
+                x.get("msDS-AllowedToActOnBehalfOfOtherIdentity", None) is not None
+            ),
         },
     }
     # TODO: Handle FSMO, SCCM cases later, file is composed of 3 JSON array
@@ -221,6 +249,74 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
             else True
         ),
     }
+
+    def has_cache_file(self, name):
+        return any(
+            path.exists(path.join(self.path, f"{self.prefix}_{name}.{extension}"))
+            for extension in ("json", "lst")
+        )
+
+    def delegation_cache_files(self):
+        available = [
+            name for name in self.DELEGATION_CACHE_FILES if self.has_cache_file(name)
+        ]
+        return ["delegations_all"] if "delegations_all" in available else available
+
+    def user_cache_files(self):
+        available = [
+            name for name in self.USER_CACHE_FILES if self.has_cache_file(name)
+        ]
+        if "users_all" in available:
+            return ["users_all"] + (["smsa"] if self.has_cache_file("smsa") else [])
+        return (
+            available
+            + (["smsa"] if self.has_cache_file("smsa") else [])
+            + self.delegation_cache_files()
+        )
+
+    def computer_cache_files(self):
+        if self.has_cache_file("machines"):
+            return ["machines"]
+        return self.delegation_cache_files()
+
+    @staticmethod
+    def _is_user_record(record):
+        classes = record.get("objectClass", [])
+        if isinstance(classes, str):
+            classes = [classes]
+        classes = {str(value).casefold() for value in classes}
+        managed_service_account = classes & {
+            "msds-groupmanagedserviceaccount",
+            "msds-managedserviceaccount",
+        }
+        return ("user" in classes or "msds-managedserviceaccount" in classes) and (
+            "computer" not in classes or managed_service_account
+        )
+
+    @staticmethod
+    def _is_computer_record(record):
+        classes = record.get("objectClass", [])
+        if isinstance(classes, str):
+            classes = [classes]
+        classes = {str(value).casefold() for value in classes}
+        return (
+            "computer" in classes
+            and "msds-groupmanagedserviceaccount" not in classes
+            and "msds-managedserviceaccount" not in classes
+        )
+
+    def USER_ALL_FILTER(self):
+        return {
+            "files": self.user_cache_files(),
+            "filter": self._is_user_record,
+        }
+
+    def COMPUTERS_FILTER(self, name):
+        return {
+            "files": self.computer_cache_files(),
+            "filter": lambda record: self._is_computer_record(record)
+            and (name == "*" or eq(record["cn"], name)),
+        }
 
     class CacheActiveDirectoryException(Exception):
         pass
@@ -292,13 +388,14 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         if base is not None:
             if "filter" in cachefilter:
                 oldFilter = cachefilter["filter"]
-                cachefilter["filter"] = lambda elt: oldFilter(elt) and (
-                    "dn" not in elt or elt["dn"].endswith("," + base)
+                cachefilter["filter"] = lambda elt: (
+                    oldFilter(elt)
+                    and ("dn" not in elt or elt["dn"].endswith("," + base))
                 )
             else:
-                cachefilter["filter"] = lambda elt: "dn" not in elt or elt[
-                    "dn"
-                ].endswith("," + base)
+                cachefilter["filter"] = lambda elt: (
+                    "dn" not in elt or elt["dn"].endswith("," + base)
+                )
 
         # Get format of cache files to use: either `lst` or `json`
         if "fmt" in cachefilter:
@@ -311,26 +408,23 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         data = []
         # For each file, retrieve result based on an optional filter
         for fil in cachefilter["files"]:
-            filename = "{prefix}_{file}.{ext}".format(
-                prefix=self.prefix, file=fil, ext=fmt
-            )
+            filename = f"{self.prefix}_{fil}.{fmt}"
             # In case the JSON file exists, parse it unless specified by the query engine
             if (
                 path.exists(path.join(self.path, filename[:-3] + "json"))
                 and not "fmt" in cachefilter
             ):
                 fmt = "json"
-                filename = "{prefix}_{file}.{ext}".format(
-                    prefix=self.prefix, file=fil, ext=fmt
-                )
+                filename = f"{self.prefix}_{fil}.{fmt}"
 
             replacement = cachefilter.get("replacement", None)
-            if not path.exists(filename) and replacement is None:
-                if filename not in warned_missing_files:
-                    error(f"{filename} required but not found")
-                    warned_missing_files.add(filename)
+            cache_path = path.join(self.path, filename)
+            if not path.exists(cache_path) and replacement is None:
+                if cache_path not in warned_missing_files:
+                    error(f"{cache_path} required but not found")
+                    warned_missing_files.add(cache_path)
                 continue
-            if not path.exists(filename) and replacement:
+            if not path.exists(cache_path) and replacement:
                 cachefilter["files"] = cachefilter["replacement"]["files"]
                 cachefilter["filter"] = cachefilter["replacement"]["filter"]
                 del cachefilter["replacement"]
@@ -342,7 +436,7 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
                 if path.join(self.path, filename) in FILE_CONTENT_DICT:
                     json = FILE_CONTENT_DICT[path.join(self.path, filename)]
                 else:
-                    fp = open(path.join(self.path, filename))
+                    fp = open(cache_path)
                     json = json_load(fp)
                     if "ntSecurityDescriptor" not in self.attributes:
                         scrub_json_from_key(json, lambda x: x == "nTSecurityDescriptor")
@@ -360,7 +454,7 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
                 if path.join(self.path, filename) in FILE_CONTENT_DICT:
                     fp = FILE_CONTENT_DICT[path.join(self.path, filename)]
                 else:
-                    fp = open(path.join(self.path, filename))
+                    fp = open(cache_path)
                     FILE_CONTENT_DICT[path.join(self.path, filename)] = fp
                 if "filter" in cachefilter:
                     for line in fp:
@@ -432,14 +526,69 @@ class CacheActiveDirectoryView(ActiveDirectoryView):
         """
         Private functions to retrieve the cache domain name.
         """
-        filename = "{prefix}_server_info.json".format(prefix=self.prefix)
-        if not path.exists(filename):
-            raise self.CacheActiveDirectoryFileNotFoundException(
-                f"{filename} not found"
-            )
-        with open(path.join(self.path, filename)) as fp:
-            info = json_load(fp)
-            base = info[0]["raw"]["defaultNamingContext"][0]
-            forest_base = info[0]["raw"]["rootDomainNamingContext"][0]
-            domain = base.replace("DC=", ".")[1:].replace(",", "")
-            return domain, base, forest_base
+        filename = f"{self.prefix}_server_info.json"
+        if path.exists(path.join(self.path, filename)):
+            with open(path.join(self.path, filename)) as fp:
+                info = json_load(fp)
+                base = info[0]["raw"]["defaultNamingContext"][0]
+                forest_base = info[0]["raw"]["rootDomainNamingContext"][0]
+                domain = base.replace("DC=", ".")[1:].replace(",", "")
+                return domain, base, forest_base
+
+        # A BloodHound conversion is useful with a deliberately partial ldeep
+        # cache (for example only users and computers).  server_info is not
+        # needed to read those JSON records, so derive a conservative naming
+        # context from the first distinguished name available instead of
+        # refusing to open the cache.
+        for cache_file in (
+            "users_all",
+            "users_enabled",
+            "users_disabled",
+            "users_locked",
+            "users_nopasswordexpire",
+            "users_passwordexpired",
+            "users_passwordnotrequired",
+            "users_nokrbpreauth",
+            "users_reversible",
+            "users_spn",
+            "smsa",
+            "delegations_all",
+            "delegations_unconstrained",
+            "delegations_constrained",
+            "delegations_rbcd",
+            "fsp",
+            "shadow_principals",
+            "groups",
+            "machines",
+            "domain_policy",
+            "gmsa",
+            "ou",
+            "gpo",
+            "pkis",
+            "conf",
+        ):
+            candidate = path.join(self.path, f"{self.prefix}_{cache_file}.json")
+            if not path.exists(candidate):
+                continue
+            try:
+                with open(candidate) as fp:
+                    records = json_load(fp)
+            except (OSError, ValueError):
+                continue
+            for record in records if isinstance(records, list) else []:
+                dn = record.get("distinguishedName") or record.get("dn")
+                if not isinstance(dn, str):
+                    continue
+                components = [
+                    component.split("=", 1)[1].strip()
+                    for component in dn.split(",")
+                    if component.split("=", 1)[0].strip().lower() == "dc"
+                    and "=" in component
+                ]
+                if components:
+                    base = ",".join(f"DC={component}" for component in components)
+                    return ".".join(components), base, base
+
+        raise self.CacheActiveDirectoryFileNotFoundException(
+            f"{filename} not found and no domain DN was found in the cache"
+        )

--- a/ldeep/views/ldap_activedirectory.py
+++ b/ldeep/views/ldap_activedirectory.py
@@ -14,9 +14,9 @@ from ldap3 import (
     DEREF_NEVER,
     ENCRYPT,
     KERBEROS,
-    MODIFY_REPLACE,
     MODIFY_ADD,
     MODIFY_DELETE,
+    MODIFY_REPLACE,
     NTLM,
     SASL,
     SIMPLE,
@@ -277,14 +277,14 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
     SHADOW_PRINCIPALS_FILTER = lambda _: "(objectClass=msDS-ShadowPrincipal)"
     FSP_FILTER = lambda _, s: f"(&(objectClass=foreignSecurityPrincipal)(cn={s}))"
     UNCONSTRAINED_DELEGATION_FILTER = (
-        lambda _: f"(userAccountControl:1.2.840.113556.1.4.803:=524288)"
+        lambda _: "(userAccountControl:1.2.840.113556.1.4.803:=524288)"
     )
-    CONSTRAINED_DELEGATION_FILTER = lambda _: f"(msDS-AllowedToDelegateTo=*)"
+    CONSTRAINED_DELEGATION_FILTER = lambda _: "(msDS-AllowedToDelegateTo=*)"
     RESOURCE_BASED_CONSTRAINED_DELEGATION_FILTER = (
-        lambda _: f"(msDS-AllowedToActOnBehalfOfOtherIdentity=*)"
+        lambda _: "(msDS-AllowedToActOnBehalfOfOtherIdentity=*)"
     )
     ALL_DELEGATIONS_FILTER = (
-        lambda _: f"(|(userAccountControl:1.2.840.113556.1.4.803:=524288)(msDS-AllowedToDelegateTo=*)(msDS-AllowedToActOnBehalfOfOtherIdentity=*))"
+        lambda _: "(|(userAccountControl:1.2.840.113556.1.4.803:=524288)(msDS-AllowedToDelegateTo=*)(msDS-AllowedToActOnBehalfOfOtherIdentity=*))"
     )
 
     class ActiveDirectoryLdapException(Exception):
@@ -442,9 +442,7 @@ class LdapActiveDirectoryView(ActiveDirectoryView):
                         sasl_mechanism=KERBEROS,
                         session_security=ENCRYPT,
                     )
-        elif method == "Certificate":
-            self.ldap = Connection(server)
-        elif method == "anonymous":
+        elif method == "Certificate" or method == "anonymous":
             self.ldap = Connection(server)
         elif method == "NTLM":
             if password is not None:


### PR DESCRIPTION
 ## Description

This pull request adds BloodHound Community Edition v6 export support to ldeep.

It introduces a dedicated `bloodhound` mode that converts existing ldeep cache files into BloodHound-compatible JSON files. The exporter supports partial caches and generates one output file per BloodHound object type.

Applied Ruff linting and Black formatting across the entire project.

## Changes

- Added the `bloodhound` CLI mode with `--dir`, `--prefix`, and `--output` options.
- Added conversion support for:
  - Domains
  - Users
  - Groups
  - Computers
  - Organizational Units
  - GPOs
  - Enterprise CAs and certificate templates
  - Configuration objects, containers, root CAs, AIAs, NTAuth stores, and issuance policies
- Added BloodHound-compatible ACL, delegation, trust, containment, membership, and certificate relationships.
- Added support for well-known SIDs and synthetic nodes when required.
- Added support for partial ldeep caches and missing `server_info` files.
- Improved cache file discovery and filtering for users, computers, GMSAs, and delegation data.
- Updated the README with BloodHound usage instructions.
- Applied minor code cleanup and compatibility improvements in existing modules.

## Usage

```bash
ldeep bloodhound -d <cache-directory> -p <cache-prefix> -o <output-directory>
```
## Tests

The conversion was tested on a lab with full and partial cache collection

## AI Assistance Disclosure

This pull request was prepared with the assistance of AI using GPT 5.6-luna high. All generated changes were tested to ensure they were working.